### PR TITLE
Configure cleanly on Mac OS X without flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,11 +20,13 @@ AC_DEFINE_UNQUOTED([VERSHEX], [(($versmaj)*0x10000+($versmid)*0x100+($versmin))]
 
 # Checks for programs.
 AC_LANG([C++])
-AC_PROG_CXX
+AC_PROG_CXX([c++ g++ clang++])
+AC_PROG_CC([cc gcc clang])
 AC_PROG_LN_S
 AC_PROG_LIBTOOL
 
-CPPFLAGS="$CPPFLAGS -std=gnu++0x -Wall -Wextra -Wshadow -pedantic -fwrapv -O2 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
+CPPFLAGS="$CPPFLAGS -Wall -Wextra -Wshadow -pedantic -fwrapv -O2 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
+CXXFLAGS="-std=gnu++0x"
 
 case $target_os in
   *linux*)


### PR DESCRIPTION
On Mac OS X, GCC is ancient and doesn't understand -std=c++0x.  To fix
this, we can prefer the system default C compiler (which happens to be
clang on Mac OS X).  We also need to break the "-std=gnu++0x" flag
into CXXFLAGS because clang doesn't like C++ flags when run in C mode.
