### PR TITLE
Remove obsolete/undocummented command line switches

### DIFF
--- a/mfsmain/main.cc
+++ b/mfsmain/main.cc
@@ -1007,19 +1007,13 @@ int main(int argc,char **argv) {
 	lockmemory = 0;
 	appname = argv[0];
 
-	while ((ch = getopt(argc, argv, "uvdfsc:t:h?")) != -1) {
+    while ((ch = getopt(argc, argv, "c:dht:uv?")) != -1) {
 		switch(ch) {
 			case 'v':
 				printf("version: %u.%u.%u\n",PACKAGE_VERSION_MAJOR,PACKAGE_VERSION_MINOR,PACKAGE_VERSION_MICRO);
 				return 0;
 			case 'd':
 				rundaemon=0;
-				break;
-			case 'f':
-				runmode=RM_START;
-				break;
-			case 's':
-				runmode=RM_STOP;
 				break;
 			case 't':
 				locktimeout=strtoul(optarg,NULL,10);


### PR DESCRIPTION
Spotted undocummented/obsolete switches '-s' and '-f' equivalent to
'start' and 'stop' respectively. Removing for convenience.
