### PR TITLE
Stable release LizardFS 1.6.28 (2013-10-16)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,11 @@
-This file lists noteworthy changes in MooseFS.
+This file lists noteworthy changes in LizardFS.
+
+* LizardFS 1.6.28 (2013-10-16)
+
+  - (all) compile with g++ by default
+  - (deb) fix init scripts for debian packages
+  - (all) fix build on Mac OS X
+  - (cgi) introducing LizardFS logo
 
 * MooseFS 1.6.27 (2012-08-09)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.60)
 dnl AC_PREREQ(2.60)
-AC_INIT([MFS], [1.6.27], [contact@lizardfs.org])
+AC_INIT([MFS], [1.6.28], [contact@lizardfs.org])
 dnl AC_INIT([MFS], [1.7.0], [contact@lizardfs.org])
 dnl AC_CONFIG_SRCDIR([MFSCommunication.h])
 AC_CONFIG_HEADER([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+mfs (1.6.28) unstable; urgency=medium
+
+  * (all) compile with g++ by default
+  * (deb) fix init scripts for debian packages
+  * (all) fix build on Mac OS X
+  * (cgi) introducing LizardFS logo
+
+ -- Peter aNeutrino <contact@lizardfs.org>  Wed, 16 Oct 2013 12:00:00 +0200
+
 mfs (1.6.27) unstable; urgency=medium
 
   * (mfsrestore) fixed bug - freeing filenames memory too early

--- a/rpm/mfs.spec
+++ b/rpm/mfs.spec
@@ -6,7 +6,7 @@
 
 Summary:	MooseFS - distributed, fault tolerant file system
 Name:		mfs
-Version:	1.6.27
+Version:	1.6.28
 Release:	1%{?distro}
 License:	GPL v3
 Group:		System Environment/Daemons
@@ -23,6 +23,8 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 %description
 MooseFS is an Open Source, easy to deploy and maintain, distributed,
 fault tolerant file system for POSIX compliant OSes.
+LizardFS is fork of MooseFS. For more information please visit
+http://lizardfs.org
 
 %package master
 Summary:	MooseFS master server
@@ -199,6 +201,12 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Wed Oct 16 2013 Peter aNeutrino <contact@lizardfs.org> - 1.6.28-1
+- (all) compile with g++ by default
+- (deb) fix init scripts for debian packages
+- (all) fix build on Mac OS X
+- (cgi) introducing LizardFS logo
+
 * Thu Feb 16 2012 Jakub Bogusz <contact@moosefs.com> - 1.6.27-1
 - adjusted to keep configuration files in /etc/mfs
 - require just mfsexports.cfg (master) and mfshdd.cfg (chunkserver) in RH-like


### PR DESCRIPTION
- (all) compile with g++ by default
- (deb) fix init scripts for debian packages
- (all) fix build on Mac OS X
- (cgi) introducing LizardFS logo
