### PR TITLE
tools: Fix conversion numbers to human readable IEC format

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -18,9 +18,14 @@ set(MFSTOOL_LINKS
   mfsrgettrashtime
   mfsrsettrashtime)
 
-aux_source_directory(. TOOLS_SOURCES)
-add_executable(mfstools ${TOOLS_SOURCES})
-target_link_libraries(mfstools mfscommon)
+collect_sources(TOOLS)
+
+add_library(tools ${TOOLS_SOURCES})
+target_link_libraries(tools ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_tests(tools ${TOOLS_TESTS})
+
+add_executable(mfstools ${TOOLS_MAIN})
+target_link_libraries(mfstools tools mfscommon)
 install(TARGETS mfstools DESTINATION ${BIN_SUBDIR})
 
 foreach(LINK ${MFSTOOL_LINKS})

--- a/src/tools/human_readable_format.cc
+++ b/src/tools/human_readable_format.cc
@@ -1,0 +1,45 @@
+#include "human_readable_format.h"
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#define BASE_SI 1000
+#define BASE_IEC 1024
+
+static std::string convertToHumanReadableFormat(const uint64_t inputNumber, const uint16_t base){
+	std::stringstream ss;
+
+	ss << std::fixed;
+	if (inputNumber < base) {
+		ss << inputNumber;
+	} else {
+		uint16_t exp = static_cast<uint16_t>(log(inputNumber) / log(base));
+		double number = inputNumber / pow(base, exp);
+
+		if (number > base - 1) { // e.g. 1023.9MiB is almost like 1024MiB, so we convert it to 1.0GiB
+			number /= base;
+			++exp;
+		}
+
+		// when number has one digit increase precision e.g. 2300 bytes is 2.3k instead of 2k
+		ss << std::setprecision(number < 10 ? 1 : 0);
+
+		if (base == BASE_SI) {
+			ss << number << "kMGTPE"[exp - 1];
+		} else {
+			ss << number << "KMGTPE"[exp - 1] << "i";
+		}
+	}
+
+	return ss.str();
+}
+
+std::string convertToSi(const uint64_t number) {
+	return convertToHumanReadableFormat(number, BASE_SI);
+}
+
+std::string convertToIec(const uint64_t number) {
+	return convertToHumanReadableFormat(number, BASE_IEC);
+}

--- a/src/tools/human_readable_format.h
+++ b/src/tools/human_readable_format.h
@@ -1,0 +1,11 @@
+#ifndef LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
+#define LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
+
+#include <cstdint>
+#include <string>
+
+std::string convertToSi(uint64_t number);
+std::string convertToIec(uint64_t number);
+
+#endif // LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
+

--- a/src/tools/human_readable_format_unittest.cc
+++ b/src/tools/human_readable_format_unittest.cc
@@ -1,0 +1,48 @@
+#include "human_readable_format.h"
+
+#include <gtest/gtest.h>
+
+TEST(HumanReadableFormatTests, ConvertToSi) {
+	EXPECT_EQ("0", convertToSi(0));
+	EXPECT_EQ("1", convertToSi(1));
+	EXPECT_EQ("999", convertToSi(999));
+	EXPECT_EQ("1.0k", convertToSi(1000));
+	EXPECT_EQ("1.0k", convertToSi(1001));
+	EXPECT_EQ("1.4k", convertToSi(1400));
+	EXPECT_EQ("1.6k", convertToSi(1550));
+
+	EXPECT_EQ("1.0M", convertToSi(1000000ULL));
+	EXPECT_EQ("1.0G", convertToSi(1000000000ULL));
+	EXPECT_EQ("1.0T", convertToSi(1000000000000ULL));
+	EXPECT_EQ("1.0P", convertToSi(1000000000000000ULL));
+	EXPECT_EQ("1.0E", convertToSi(1000000000000000000ULL));
+	EXPECT_EQ("10E", convertToSi(10000000000000000000ULL));
+
+	EXPECT_EQ("18E", convertToSi(18446744073709551615ULL));
+}
+
+TEST(HumanReadableFormatTests, ConvertToIec) {
+	EXPECT_EQ("0", convertToIec(0));
+	EXPECT_EQ("1", convertToIec(1));
+
+	EXPECT_EQ("1000", convertToIec(1000));
+	EXPECT_EQ("1.5Ki", convertToIec(1550));
+
+	EXPECT_EQ("1023", convertToIec(1023));
+	EXPECT_EQ("1.0Ki", convertToIec(1024));
+	EXPECT_EQ("1.0Ki", convertToIec(1025));
+	EXPECT_EQ("1023Ki", convertToIec(1023 * 1024));
+	EXPECT_EQ("1023Pi", convertToIec(1023ULL * 1024 * 1024 * 1024 * 1024 * 1024));
+
+	EXPECT_EQ("888Pi", convertToIec(1000000000000000000ULL));
+	EXPECT_EQ("8.7Ei", convertToIec(10000000000000000000ULL));
+
+	EXPECT_EQ("1.0Mi", convertToIec(1024ULL * 1024));
+	EXPECT_EQ("1.0Gi", convertToIec(1024ULL * 1024 * 1024));
+	EXPECT_EQ("1.0Ti", convertToIec(1024ULL * 1024 * 1024 * 1024));
+	EXPECT_EQ("1.0Pi", convertToIec(1024ULL * 1024 * 1024 * 1024 * 1024));
+	EXPECT_EQ("1.0Ei", convertToIec(1024ULL * 1024 * 1024 * 1024 * 1024 * 1024));
+
+	EXPECT_EQ("16Ei", convertToIec(18446744073709551615ULL));
+}
+


### PR DESCRIPTION
Function 'print_humanized_number' has been refactored.
In addition there was a bug for 'IEC' format convertion:
Old function was returning e.g.: '1.0KiB' for '1023' bytes..
The bug was a result of using always '1000' as a 'base'
for both 'SI' and 'IEC' rounding. The 'base' should be accordingly:
'1000' and '1024', even for rounding.
