### PR TITLE
Introduce crcutil library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *~
 .DS_Store
 
+# External libraries #
+######################
+/external/crcutil-1.0
+
 # Vim files #
 #############
 .clang_complete

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=gnu++0x -Wall -Wextra -Wshadow -pedantic -fwrapv")
+set(CMAKE_CXX_FLAGS "-std=gnu++0x -Wall -Wextra -pedantic -fwrapv")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
@@ -80,13 +80,13 @@ include(EnvTests.cmake)
 set(DATA_PATH "${CMAKE_INSTALL_PREFIX}/${DATA_SUBDIR}")
 set(ETC_PATH "${CMAKE_INSTALL_PREFIX}/${ETC_SUBDIR}")
 set(RUN_PATH "${CMAKE_INSTALL_PREFIX}/${RUN_SUBDIR}")
-
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_BINARY_DIR}) # Here we have generated config.h
 
 # main.cc shared by some LizardFS applications
 set(MAIN_SRC ${CMAKE_SOURCE_DIR}/src/main/main.cc)
 
+add_subdirectory(external)
 add_subdirectory(src/common)
 add_subdirectory(src/chunkserver)
 add_subdirectory(src/master)

--- a/Libraries.cmake
+++ b/Libraries.cmake
@@ -1,6 +1,43 @@
-find_package(ZLIB REQUIRED)
+# Download crcutil
+set(CRCUTIL_VERSION crcutil-1.0)
+set(CRCUTIL_ARCHIVE ${CRCUTIL_VERSION}.tar.gz)
+set(CRCUTIL_URL http://crcutil.googlecode.com/files/${CRCUTIL_ARCHIVE})
+set(CRCUTIL_MD5 94cb7014d4078c138d3c9646fcf1fec5)
+if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION})
+  message(STATUS "Downloading ${CRCUTIL_URL} ...")
+  file(DOWNLOAD
+      ${CRCUTIL_URL}
+      ${CMAKE_BINARY_DIR}/${CRCUTIL_ARCHIVE}
+      INACTIVITY_TIMEOUT 15
+      STATUS DOWNLOAD_STATUS
+      EXPECTED_MD5 ${CRCUTIL_MD5}
+      SHOW_PROGRESS)
+  list(GET DOWNLOAD_STATUS 0 DOWNLOAD_STATUS_ERROR_CODE)
+  list(GET DOWNLOAD_STATUS 1 DOWNLOAD_STATUS_MESSAGE)
+  if (NOT DOWNLOAD_STATUS_ERROR_CODE EQUAL 0)
+    message(FATAL_ERROR "Downloading failed: ${DOWNLOAD_STATUS_MESSAGE}")
+  endif()
+  message(STATUS "Unpacking ${CRCUTIL_ARCHIVE} ...")
+  execute_process(COMMAND tar -xzf ${CMAKE_BINARY_DIR}/${CRCUTIL_ARCHIVE}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external
+      RESULT_VARIABLE TAR_ERROR
+      ERROR_VARIABLE  TAR_ERROR_MESSAGE)
+  if(NOT TAR_ERROR STREQUAL 0)
+    message(FATAL_ERROR "tar -xzf ${CRCUTIL_ARCHIVE} failed: ${TAR_ERROR_MESSAGE}")
+  endif()
+  if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION})
+    message(FATAL_ERROR "Extracting ${CRCUTIL_ARCHIVE} didn't produce directory ${CRCUTIL_VERSION}")
+  endif()
+endif()
+
+# Find standard libraries
 find_package(Socket)
 find_package(Threads)
-
+find_package(ZLIB REQUIRED)
 find_library(FUSE_LIBRARY fuse)
 message(STATUS "FUSE_LIBRARY: ${FUSE_LIBRARY}")
+
+# Find crcutil
+set(CRCUTIL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION}/code)
+set(CRCUTIL_SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION}/code)
+set(CRCUTIL_CXX_FLAGS "-mcrc32")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,5 @@
+# crcutil
+include_directories(${CRCUTIL_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CRCUTIL_CXX_FLAGS}")
+file(GLOB CRCUTIL_SOURCES ${CRCUTIL_SOURCE_DIR}/*.cc)
+add_library(crcutil ${CRCUTIL_SOURCES})

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,9 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+# Use crcutil Library
+include_directories(${CRCUTIL_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CRCUTIL_CXX_FLAGS}")
+
 aux_source_directory(. COMMON_SOURCES)
 add_library(mfscommon ${COMMON_SOURCES})
+target_link_libraries(mfscommon crcutil)


### PR DESCRIPTION
This commits adds a possibility to use crcutil library in the LizardFS
code. This library is automatically downloaded when cmake is being run.
