### PR TITLE
tests: Add GoogleTest framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # External libraries #
 ######################
 /external/crcutil-1.0
+/external/gtest-1.7.0
 
 # Vim files #
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,16 @@ set(DEFAULT_USER "mfs" CACHE STRING "Default user to run daemons as")
 set(DEFAULT_GROUP "mfs" CACHE STRING "Default group to run daemons as")
 set(ENABLE_LIGHTMFS NO CACHE BOOL "Enable light version of LizardFS")
 set(ENABLE_DEBIAN_PATHS NO CACHE BOOL "Enable Debian-style install paths")
+set(ENABLE_TESTS  NO CACHE STRING "Enable building tests")
 
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "ENABLE_LIGHTMFS: ${ENABLE_LIGHTMFS}")
 message(STATUS "ENABLE_DEBIAN_PATHS: ${ENABLE_DEBIAN_PATHS}")
+message(STATUS "ENABLE_TESTS: ${ENABLE_TESTS}")
+
+## All the environment tests (libs, includes, etc.) live here:
+include(EnvTests.cmake)
 
 if(ENABLE_DEBIAN_PATHS)
   if (NOT CMAKE_INSTALL_PREFIX STREQUAL "/")
@@ -71,10 +76,14 @@ else()
   set(LIGHT_MFS 0)
 endif()
 
-set(CHARTS_CSV_CHARTID_BASE 90000)
+if(ENABLE_TESTS)
+  if(NOT Boost_FOUND)
+    message(FATAL_ERROR "Boost is required by LizardFS tests")
+  endif()
+  set(BUILD_TESTS ON)
+endif()
 
-## All the environment tests (libs, includes, etc.) live here:
-include(EnvTests.cmake)
+set(CHARTS_CSV_CHARTID_BASE 90000)
 
 # Create config.h file
 set(DATA_PATH "${CMAKE_INSTALL_PREFIX}/${DATA_SUBDIR}")

--- a/Libraries.cmake
+++ b/Libraries.cmake
@@ -30,10 +30,53 @@ if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION})
   endif()
 endif()
 
+# Download GoogleTest
+if(ENABLE_TESTS)
+  set(GTEST_VERSION 1.7.0)
+  set(GTEST_NAME gtest-${GTEST_VERSION})
+
+  if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/external/${GTEST_NAME})
+    set(GTEST_ARCHIVE ${GTEST_NAME}.zip)
+    set(GTEST_URL http://googletest.googlecode.com/files/${GTEST_ARCHIVE})
+    set(GTEST_ARCHIVE_MD5 2d6ec8ccdf5c46b05ba54a9fd1d130d7)
+
+    message(STATUS "Downloading ${GTEST_URL}...")
+    file(DOWNLOAD
+        ${GTEST_URL}
+        ${CMAKE_BINARY_DIR}/${GTEST_ARCHIVE}
+        INACTIVITY_TIMEOUT 15
+        SHOW_PROGRESS
+        STATUS DOWNLOAD_STATUS
+        EXPECTED_MD5 ${GTEST_ARCHIVE_MD5})
+
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_CODE)
+    if(NOT DOWNLOAD_CODE EQUAL 0)
+      list(GET DOWNLOAD_STATUS 1 DOWNLOAD_MESSAGE)
+      message(FATAL_ERROR "Download ${GTEST_URL} error ${DOWNLOAD_CODE}: ${DOWNLOAD_MESSAGE}")
+    endif()
+
+    message(STATUS "Unpacking ${GTEST_ARCHIVE}...")
+    execute_process(COMMAND unzip -q ${CMAKE_BINARY_DIR}/${GTEST_ARCHIVE}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external
+      RESULT_VARIABLE UNZIP_ERROR
+      ERROR_VARIABLE UNZIP_ERROR_MESSAGE)
+    if(NOT UNZIP_ERROR STREQUAL 0)
+    message(FATAL_ERROR "unzip ${GTEST_ARCHIVE} failed: ${UNZIP_ERROR} ${UNZIP_ERROR_MESSAGE}")
+    endif()
+    if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/external/${GTEST_NAME})
+      message(FATAL_ERROR "Extracting ${GTEST_ARCHIVE} didn't produce directory '${GTEST_NAME}'")
+    endif()
+    message(STATUS "Downloading ${GTEST_NAME} finished successfully")
+  else()
+    message(STATUS "Found ${GTEST_NAME}")
+  endif()
+endif()
+
 # Find standard libraries
 find_package(Socket)
 find_package(Threads)
 find_package(ZLIB REQUIRED)
+find_package(Boost COMPONENTS filesystem system regex thread)
 find_library(FUSE_LIBRARY fuse)
 message(STATUS "FUSE_LIBRARY: ${FUSE_LIBRARY}")
 
@@ -41,3 +84,8 @@ message(STATUS "FUSE_LIBRARY: ${FUSE_LIBRARY}")
 set(CRCUTIL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION}/code)
 set(CRCUTIL_SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/${CRCUTIL_VERSION}/code)
 set(CRCUTIL_CXX_FLAGS "-mcrc32")
+
+# Find GoogleTest
+if(ENABLE_TESTS)
+  set(GTEST_INCLUDE_DIRS ${GTEST_NAME}/include)
+endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,3 +3,9 @@ include_directories(${CRCUTIL_INCLUDE_DIRS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CRCUTIL_CXX_FLAGS}")
 file(GLOB CRCUTIL_SOURCES ${CRCUTIL_SOURCE_DIR}/*.cc)
 add_library(crcutil ${CRCUTIL_SOURCES})
+
+# GoogleTest
+if(BUILD_TESTS)
+  include_directories(${GTEST_INCLUDE_DIRS})
+  add_subdirectory(${GTEST_NAME})
+endif()


### PR DESCRIPTION
This commit provides capability to make unit-tests using GoogleTest framework.
Framework is downloaded automatically to source directory (external/gtest*)
during project configuration.
