### PR TITLE
common: Fix wrong index calculation for pointers array

### DIFF
--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -1921,7 +1921,7 @@ uint32_t charts_make_csv(uint32_t number) {
 	tm_year = tm_mon = tm_day = tm_hour = tm_min = tm_sec = 0;
 
 	type = number / 10;
-	range = number % 10;
+	range = number % RANGES;
 	charts_filltab(c1dispdata, range, type, 1);
 	charts_filltab(c2dispdata, range, type, 2);
 	charts_filltab(c3dispdata, range, type, 3);


### PR DESCRIPTION
There was a possibilty of too big index usage.
it was reported by 'warning: array subscript is above array bounds'
