### PR TITLE
Migrate include guards to #pragma once from #define 

### DIFF
--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _BGJOBS_H_
-#define _BGJOBS_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -49,5 +48,3 @@ uint32_t job_write(void *jpool,void (*callback)(uint8_t status,void *extra),void
 /* srcs: srccnt * (chunkid:64 version:32 ip:32 port:16) */
 uint32_t job_replicate(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra,uint64_t chunkid,uint32_t version,uint8_t srccnt,const uint8_t *srcs);
 uint32_t job_replicate_simple(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra,uint64_t chunkid,uint32_t version,uint32_t ip,uint16_t port);
-
-#endif

--- a/src/chunkserver/chartsdata.h
+++ b/src/chunkserver/chartsdata.h
@@ -16,11 +16,8 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHARTSDATA_H_
-#define _CHARTSDATA_H_
+#pragma once
 
 #include <inttypes.h>
 
 int chartsdata_init (void);
-
-#endif

--- a/src/chunkserver/csserv.h
+++ b/src/chunkserver/csserv.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CSSERV_H_
-#define _CSSERV_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ void csserv_stats(uint64_t *bin,uint64_t *bout,uint32_t *hlopr,uint32_t *hlopw,u
 uint32_t csserv_getlistenip();
 uint16_t csserv_getlistenport();
 int csserv_init(void);
-
-#endif

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _HDDSPACEMGR_H_
-#define _HDDSPACEMGR_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -89,4 +88,3 @@ int hdd_init(void);
 /* debug only */
 void hdd_test_show_chunks(void);
 void hdd_test_show_openedchunks(void);
-#endif

--- a/src/chunkserver/masterconn.h
+++ b/src/chunkserver/masterconn.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MASTERCONN_H_
-#define _MASTERCONN_H_
+#pragma once
 
 #include <inttypes.h>
 
 void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt);
 int masterconn_init(void);
-
-#endif

--- a/src/chunkserver/replicator.h
+++ b/src/chunkserver/replicator.h
@@ -16,13 +16,10 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _REPLICATOR_H_
-#define _REPLICATOR_H_
+#pragma once
 
 #include <inttypes.h>
 
 void replicator_stats(uint32_t *repl);
 /* srcs: srccnt * (chunkid:64 version:32 ip:32 port:16) */
 uint8_t replicate(uint64_t chunkid,uint32_t version,uint8_t srccnt,const uint8_t *srcs);
-
-#endif

--- a/src/common/MFSCommunication.h
+++ b/src/common/MFSCommunication.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MFS_COMMUNICATION_H_
-#define _MFS_COMMUNICATION_H_
+#pragma once
 
 // all data field transfered in network order.
 // packet structure:
@@ -1249,5 +1248,3 @@
 // 0x00259
 #define CSTOCL_HDD_LIST_V2 (PROTO_BASE+601)
 // N*[ entrysize:16 path:NAME flags:8 errchunkid:64 errtime:32 used:64 total:64 chunkscount:32 bytesread:64 usecread:64 usecreadmax:64 byteswriten:64 usecwrite:64 usecwritemax:64]
-
-#endif

--- a/src/common/cfg.h
+++ b/src/common/cfg.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CFG_H_
-#define _CFG_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -40,5 +39,3 @@ _CONFIG_MAKE_PROTOTYPE(int32,int32_t);
 _CONFIG_MAKE_PROTOTYPE(uint64,uint64_t);
 _CONFIG_MAKE_PROTOTYPE(int64,int64_t);
 _CONFIG_MAKE_PROTOTYPE(double,double);
-
-#endif

--- a/src/common/charts.h
+++ b/src/common/charts.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHARTS_H_
-#define _CHARTS_H_
+#pragma once
 
 #include <stdio.h>
 #include <inttypes.h>
@@ -141,5 +140,3 @@ void charts_add (uint64_t *data,uint32_t datats);
 void charts_store (void);
 int charts_init (const uint32_t *calcs,const statdef *stats,const estatdef *estats,const char *filename);
 void charts_term (void);
-
-#endif

--- a/src/common/crc.h
+++ b/src/common/crc.h
@@ -16,8 +16,8 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CRC_H_
-#define _CRC_H_
+#pragma once
+
 #include <inttypes.h>
 
 uint32_t mycrc32(uint32_t crc,const uint8_t *block,uint32_t leng);
@@ -27,5 +27,3 @@ uint32_t mycrc32_combine(uint32_t crc1, uint32_t crc2, uint32_t leng2);
 #define mycrc32_xorblocks(crc,crcblock1,crcblock2,leng) ((crcblock1)^(crcblock2)^mycrc32_zeroblock(crc,leng))
 
 void mycrc32_init(void);
-
-#endif

--- a/src/common/datapack.h
+++ b/src/common/datapack.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _DATAPACK_H_
-#define _DATAPACK_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -83,5 +82,3 @@ static inline uint8_t get8bit(const uint8_t **ptr) {
 	(*ptr)++;
 	return t8;
 }
-
-#endif

--- a/src/common/hashfn.h
+++ b/src/common/hashfn.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _HASHFN_H_
-#define _HASHFN_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -71,5 +70,3 @@ static inline uint64_t hash64(uint64_t key) {
 	key = key + (key << 31);
 	return key;
 }
-
-#endif

--- a/src/common/main.h
+++ b/src/common/main.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MAIN_H_
-#define _MAIN_H_
+#pragma once
 
 #include <poll.h>
 #include <inttypes.h>
@@ -35,5 +34,3 @@ void* main_timeregister (int mode,uint32_t seconds,uint32_t offset,void (*fun)(v
 int main_timechange(void *x,int mode,uint32_t seconds,uint32_t offset);
 uint32_t main_time(void);
 uint64_t main_utime(void);
-
-#endif

--- a/src/common/massert.h
+++ b/src/common/massert.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MASSERT_H_
-#define _MASSERT_H_
+#pragma once
 
 #include <errno.h>
 #include <stdio.h>
@@ -41,5 +40,3 @@
 		fprintf(stderr,"unexpected status, '%s' returned: %s\n",#e,_mfs_errorstring); \
 		abort(); \
 	}
-
-#endif

--- a/src/common/md5.h
+++ b/src/common/md5.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MD5_H_
-#define _MD5_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -30,5 +29,3 @@ typedef struct _md5ctx {
 void md5_init(md5ctx *ctx);
 void md5_update(md5ctx *ctx,const uint8_t *buff,uint32_t leng);
 void md5_final(uint8_t digest[16],md5ctx *ctx);
-
-#endif

--- a/src/common/message_receive_buffer.h
+++ b/src/common/message_receive_buffer.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_MESSAGE_RECEIVE_BUFFER_H
-#define LIZARDFS_COMMON_MESSAGE_RECEIVE_BUFFER_H
+#pragma once
 
 #include <inttypes.h>
 #include <vector>
@@ -72,5 +71,3 @@ private:
 	std::vector<uint8_t> buffer_;
 	size_t bytesReveived_;
 };
-
-#endif /* LIZARDFS_COMMON_MESSAGE_RECEIVE_BUFFER_H */

--- a/src/common/mfsstrerr.h
+++ b/src/common/mfsstrerr.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MFSSTRERR_H_
-#define _MFSSTRERR_H_
+#pragma once
 
 #include "common/MFSCommunication.h"
 
@@ -28,5 +27,3 @@ static inline const char* mfsstrerr(uint8_t status) {
 	}
 	return errtab[status];
 }
-
-#endif

--- a/src/common/multi_buffer_writer.h
+++ b/src/common/multi_buffer_writer.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_MULTI_BUFFER_WRITER_H
-#define LIZARDFS_COMMON_MULTI_BUFFER_WRITER_H
+#pragma once
 
 #include <sys/uio.h>
 #include <vector>
@@ -32,5 +31,3 @@ private:
 	std::vector<struct iovec> buffers_;
 	size_t buffersCompletelySent_;
 };
-
-#endif /* LIZARDFS_COMMON_MULTI_BUFFER_WRITER_H */

--- a/src/common/network_address.h
+++ b/src/common/network_address.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_NETWORK_ADDRESS_H_
-#define LIZARDFS_COMMON_NETWORK_ADDRESS_H_
+#pragma once
 
 #include <arpa/inet.h>
 
@@ -58,5 +57,3 @@ struct hash<NetworkAddress> {
 	}
 };
 }
-
-#endif // LIZARDFS_COMMON_NETWORK_ADDRESS_H_

--- a/src/common/packet.h
+++ b/src/common/packet.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_PACKET_H_
-#define LIZARDFS_COMMON_PACKET_H_
+#pragma once
 
 #include <inttypes.h>
 #include <memory>
@@ -235,5 +234,3 @@ inline void verifyPacketVersionNoHeader(const std::vector<uint8_t>& packetWithou
 		throw IncorrectDeserializationException();
 	}
 }
-
-#endif // LIZARDFS_COMMON_PACKET_H_

--- a/src/common/pcqueue.h
+++ b/src/common/pcqueue.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _PCQUEUE_H_
-#define _PCQUEUE_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -31,5 +30,3 @@ void queue_put(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng);
 int queue_tryput(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng);
 void queue_get(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng);
 int queue_tryget(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng);
-
-#endif

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _RC4RANDOM_H_
-#define _RC4RANDOM_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -28,5 +27,3 @@ uint64_t rndu64();
 
 uint64_t rndu64_ranged(uint64_t range);
 uint32_t rndu32_ranged(uint32_t range);
-
-#endif

--- a/src/common/serialization.h
+++ b/src/common/serialization.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_SERIALIZATION_H_
-#define LIZARDFS_COMMON_SERIALIZATION_H_
+#pragma once
 
 #include <exception>
 #include <vector>
@@ -175,5 +174,3 @@ template<class... Args>
 inline uint32_t deserialize(const std::vector<uint8_t>& sourceBuffer, Args&... args) {
 	return deserialize(sourceBuffer.data(), sourceBuffer.size(), args...);
 }
-
-#endif // LIZARDFS_COMMON_SERIALIZATION_H_

--- a/src/common/slogger.h
+++ b/src/common/slogger.h
@@ -1,5 +1,4 @@
-#ifndef _SLOGGER_H_
-#define _SLOGGER_H_
+#pragma once
 
 #include <stdio.h>
 #include <syslog.h>
@@ -32,5 +31,3 @@
 
 #define mfs_errlog_silent(priority,msg) syslog((priority),"%s: %s", msg, strerr(errno));
 #define mfs_arg_errlog_silent(priority,format, ...) syslog((priority),format ": %s", __VA_ARGS__ , strerr(errno));
-
-#endif

--- a/src/common/sockets.h
+++ b/src/common/sockets.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _SOCKETS_H_
-#define _SOCKETS_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -58,5 +57,3 @@ int udpstrlisten(int sock,const char *hostname,const char *service);
 int udpwrite(int sock,uint32_t ip,uint16_t port,const void *buff,uint16_t leng);
 int udpread(int sock,uint32_t *ip,uint16_t *port,void *buff,uint16_t leng);
 int udpclose(int sock);
-
-#endif

--- a/src/common/strerr.h
+++ b/src/common/strerr.h
@@ -16,11 +16,8 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _STRERR_H_
-#define _STRERR_H_
+#pragma once
 
 const char* strerr(int error);
 void strerr_init(void);
 void strerr_term(void);
-
-#endif

--- a/src/common/time_utils.h
+++ b/src/common/time_utils.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_COMMON_TIME_UTILS_H_
-#define LIZARDFS_COMMON_TIME_UTILS_H_
+#pragma once
 
 #include <chrono>
 #include <cstdint>
@@ -73,5 +72,3 @@ public:
 private:
 	SteadyDuration timeout_;
 };
-
-#endif /* LIZARDFS_COMMON_TIME_UTILS_H_ */

--- a/src/master/changelog.h
+++ b/src/master/changelog.h
@@ -16,13 +16,10 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHANGELOG_H_
-#define _CHANGELOG_H_
+#pragma once
 
 #include <inttypes.h>
 
 void changelog_rotate(void);
 void changelog(uint64_t version,const char *format,...);
 int changelog_init(void);
-
-#endif

--- a/src/master/chartsdata.h
+++ b/src/master/chartsdata.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHARTSDATA_H_
-#define _CHARTSDATA_H_
+#pragma once
 
 #include <inttypes.h>
 
 uint64_t chartsdata_memusage(void);
 int chartsdata_init (void);
-
-#endif

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -16,8 +16,8 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHUNKS_H_
-#define _CHUNKS_H_
+#pragma once
+
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -76,5 +76,3 @@ void chunk_store(FILE *fd);
 void chunk_term(void);
 void chunk_newfs(void);
 int chunk_strinit(void);
-
-#endif

--- a/src/master/datacachemgr.h
+++ b/src/master/datacachemgr.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _DATACACHEMGR_H_
-#define _DATACACHEMGR_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ int dcm_open(uint32_t inode,uint32_t sessionid);
 void dcm_access(uint32_t inode,uint32_t sessionid);
 void dcm_modify(uint32_t inode,uint32_t sessionid);
 int dcm_init(void);
-
-#endif

--- a/src/master/exports.h
+++ b/src/master/exports.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EXPORTS_H_
-#define _EXPORTS_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ uint32_t exports_info_size(uint8_t versmode);
 void exports_info_data(uint8_t versmode,uint8_t *buff);
 uint8_t exports_check(uint32_t ip,uint32_t version,uint8_t meta,const uint8_t *path,const uint8_t rndcode[32],const uint8_t passcode[16],uint8_t *sesflags,uint32_t *rootuid,uint32_t *rootgid,uint32_t *mapalluid,uint32_t *mapallgid,uint8_t *mingoal,uint8_t *maxgoal,uint32_t *mintrashtime,uint32_t *maxtrashtime);
 int exports_init(void);
-
-#endif

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -16,13 +16,11 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _FILESYSTEM_H_
-#define _FILESYSTEM_H_
+#pragma once
 
 #include <inttypes.h>
 
 #ifdef METARESTORE
-
 
 uint64_t fs_getversion(void);
 
@@ -163,7 +161,4 @@ void fs_incversion(uint64_t chunkid);
 void fs_cs_disconnected(void);
 
 int fs_init(void);
-#endif
-
-
 #endif

--- a/src/master/itree.h
+++ b/src/master/itree.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _ITREE_H_
-#define _ITREE_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ void* itree_rebalance(void *o);
 void* itree_add_interval(void *o,uint32_t f,uint32_t t,uint32_t id);
 uint32_t itree_find(void *o,uint32_t v);
 void itree_freeall(void *o);
-
-#endif

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MATOCLSERV_H_
-#define _MATOCLSERV_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -33,5 +32,3 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status);
 void matoclserv_init_sessions(uint32_t sessionid,uint32_t inode);
 int matoclserv_sessionsinit(void);
 int matoclserv_networkinit(void);
-
-#endif

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MATOCSSERV_H_
-#define _MATOCSSERV_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -44,5 +43,3 @@ int matocsserv_send_duplicatechunk(void *e,uint64_t chunkid,uint32_t version,uin
 int matocsserv_send_truncatechunk(void *e,uint64_t chunkid,uint32_t length,uint32_t version,uint32_t oldversion);
 int matocsserv_send_duptruncchunk(void *e,uint64_t chunkid,uint32_t version,uint64_t oldchunkid,uint32_t oldversion,uint32_t length);
 int matocsserv_init(void);
-
-#endif

--- a/src/master/matomlserv.h
+++ b/src/master/matomlserv.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MATOMLSERV_H_
-#define _MATOMLSERV_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -27,5 +26,3 @@ void matomlserv_mloglist_data(uint8_t *ptr);
 void matomlserv_broadcast_logstring(uint64_t version,uint8_t *logstr,uint32_t logstrsize);
 void matomlserv_broadcast_logrotate();
 int matomlserv_init(void);
-
-#endif

--- a/src/master/topology.h
+++ b/src/master/topology.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TOPOLOGY_H_
-#define _TOPOLOGY_H_
+#pragma once
 
 #include <inttypes.h>
 
 uint8_t topology_distance(uint32_t ip1,uint32_t ip2);
 int topology_init(void);
-
-#endif

--- a/src/metalogger/masterconn.h
+++ b/src/metalogger/masterconn.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MASTERCONN_H_
-#define _MASTERCONN_H_
+#pragma once
 
 #include <inttypes.h>
 #include <stdio.h>
 
 int masterconn_init(void);
-
-#endif

--- a/src/metarestore/merger.h
+++ b/src/metarestore/merger.h
@@ -1,9 +1,6 @@
-#ifndef _MERGER_H_
-#define _MERGER_H_
+#pragma once
 
 #include <inttypes.h>
 
 int merger_start(uint32_t files,char **filenames,uint64_t maxhole);
 int merger_loop(void);
-
-#endif

--- a/src/metarestore/restore.h
+++ b/src/metarestore/restore.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _RESTORE_H_
-#define _RESTORE_H_
+#pragma once
 
 #include <inttypes.h>
 
 int restore(const char *filename,uint64_t lv,char *ptr);
 void restore_setverblevel(uint8_t _vlevel);
-
-#endif

--- a/src/mount/chunkloccache.h
+++ b/src/mount/chunkloccache.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CHUNKLOC_CACHE_H_
-#define _CHUNKLOC_CACHE_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ void chunkloc_cache_insert(uint32_t inode,uint32_t pos,uint64_t chunkid,uint32_t
 int chunkloc_cache_search(uint32_t inode,uint32_t pos,uint64_t *chunkid,uint32_t *chunkversion,uint8_t *csdatasize,const uint8_t **csdata);
 void chunkloc_cache_init(void);
 void chunkloc_cache_term(void);
-
-#endif

--- a/src/mount/chunkserver_write_chain.h
+++ b/src/mount/chunkserver_write_chain.h
@@ -1,5 +1,4 @@
-#ifndef CHUNKSERVER_WRITE_CHAIN_H
-#define CHUNKSERVER_WRITE_CHAIN_H
+#pragma once
 
 #include "common/massert.h"
 #include "common/network_address.h"
@@ -46,5 +45,3 @@ private:
 
 	std::vector<NetworkAddress> servers_;
 };
-
-#endif /* CHUNKSERVER_WRITE_CHAIN_H */

--- a/src/mount/cscomm.h
+++ b/src/mount/cscomm.h
@@ -16,9 +16,6 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CSCOMM_H_
-#define _CSCOMM_H_
+#pragma once
 
 int cs_readblock(int fd,uint64_t chunkid,uint32_t version,uint32_t offset,uint32_t size,uint8_t *buff);
-
-#endif

--- a/src/mount/csdb.h
+++ b/src/mount/csdb.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CSDB_H_
-#define _CSDB_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -30,5 +29,3 @@ void csdb_readinc(uint32_t ip,uint16_t port);
 void csdb_readdec(uint32_t ip,uint16_t port);
 void csdb_writeinc(uint32_t ip,uint16_t port);
 void csdb_writedec(uint32_t ip,uint16_t port);
-
-#endif

--- a/src/mount/dirattrcache.h
+++ b/src/mount/dirattrcache.h
@@ -16,12 +16,9 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _DIRATTRCACHE_H_
-#define _DIRATTRCACHE_H_
+#pragma once
 
 void* dcache_new(const struct fuse_ctx *ctx,uint32_t parent,const uint8_t *dbuff,uint32_t dsize);
 void dcache_release(void *r);
 uint8_t dcache_lookup(const struct fuse_ctx *ctx,uint32_t parent,uint8_t nleng,const uint8_t *name,uint32_t *inode,uint8_t attr[35]);
 uint8_t dcache_getattr(const struct fuse_ctx *ctx,uint32_t inode,uint8_t attr[35]);
-
-#endif

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MASTERCOMM_H_
-#define _MASTERCOMM_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -70,5 +69,3 @@ int fs_init_master_connection(const char *bindhostname,const char *masterhostnam
 // called after fork
 void fs_init_threads(uint32_t retries);
 void fs_term(void);
-
-#endif

--- a/src/mount/masterproxy.h
+++ b/src/mount/masterproxy.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MASTERPROXY_H_
-#define _MASTERPROXY_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ void masterproxy_getlocation(uint8_t *masterinfo);
 
 void masterproxy_term(void);
 int masterproxy_init(void);
-
-#endif

--- a/src/mount/mfs_fuse.h
+++ b/src/mount/mfs_fuse.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MFS_FUSE_H_
-#define _MFS_FUSE_H_
+#pragma once
 
 #include <fuse/fuse_lowlevel.h>
 
@@ -58,5 +57,3 @@ void mfs_getxattr (fuse_req_t req, fuse_ino_t ino, const char *name, size_t size
 void mfs_listxattr (fuse_req_t req, fuse_ino_t ino, size_t size);
 void mfs_removexattr (fuse_req_t req, fuse_ino_t ino, const char *name);
 void mfs_init(int debug_mode_in,int keep_cache_in,double direntry_cache_timeout_in,double entry_cache_timeout_in,double attr_cache_timeout_in,int mkdir_copy_sgid_in,int sugid_clear_mode_in);
-
-#endif

--- a/src/mount/mfs_meta_fuse.h
+++ b/src/mount/mfs_meta_fuse.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MFS_META_FUSE_H_
-#define _MFS_META_FUSE_H_
+#pragma once
 
 #include <fuse/fuse_lowlevel.h>
 
@@ -39,5 +38,3 @@ void mfs_meta_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 void mfs_meta_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, struct fuse_file_info *fi);
 void mfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size, off_t off, struct fuse_file_info *fi);
 void mfs_meta_init(int debug_mode_in,double entry_cache_timeout_in,double attr_cache_timeout_in);
-
-#endif

--- a/src/mount/oplog.h
+++ b/src/mount/oplog.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _OPLOG_H_
-#define _OPLOG_H_
+#pragma once
 
 #include <fuse/fuse_lowlevel.h>
 #include <inttypes.h>
@@ -35,5 +34,3 @@ unsigned long oplog_newhandle(int hflag);
 void oplog_releasehandle(unsigned long fh);
 void oplog_getdata(unsigned long fh,uint8_t **buff,uint32_t *leng,uint32_t maxleng);
 void oplog_releasedata(unsigned long fh);
-
-#endif

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _READDATA_H_
-#define _READDATA_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -28,5 +27,3 @@ int read_data(void *rr,uint64_t offset,uint32_t *size,uint8_t **buff);
 void read_data_freebuff(void *rr);
 void read_data_init(uint32_t retries);
 void read_data_term(void);
-
-#endif

--- a/src/mount/stats.h
+++ b/src/mount/stats.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _STATS_H_
-#define _STATS_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -28,5 +27,3 @@ void stats_show_all(char **buff,uint32_t *leng);
 void stats_lock(void);
 void stats_unlock(void);
 void stats_term(void);
-
-#endif

--- a/src/mount/symlinkcache.h
+++ b/src/mount/symlinkcache.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _SYMLINKCACHE_H_
-#define _SYMLINKCACHE_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -25,5 +24,3 @@ void symlink_cache_insert(uint32_t inode,const uint8_t *path);
 int symlink_cache_search(uint32_t inode,const uint8_t **path);
 void symlink_cache_init(void);
 void symlink_cache_term(void);
-
-#endif

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -16,8 +16,7 @@
    along with LizardFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _WRITEDATAALT_H_
-#define _WRITEDATAALT_H_
+#pragma once
 
 #include <inttypes.h>
 
@@ -29,5 +28,3 @@ int write_data_flush(void *vid);
 uint64_t write_data_getmaxfleng(uint32_t inode);
 int write_data_flush_inode(uint32_t inode);
 int write_data(void *vid,uint64_t offset,uint32_t size,const uint8_t *buff);
-
-#endif

--- a/src/tools/human_readable_format.h
+++ b/src/tools/human_readable_format.h
@@ -1,11 +1,7 @@
-#ifndef LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
-#define LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
+#pragma once
 
 #include <cstdint>
 #include <string>
 
 std::string convertToSi(uint64_t number);
 std::string convertToIec(uint64_t number);
-
-#endif // LIZARDFS_TOOLS_HUMAN_READABLE_FORMAT_H_
-

--- a/utils/asserts.h
+++ b/utils/asserts.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_UTILS_ASSERTS_H_
-#define LIZARDFS_UTILS_ASSERTS_H_
+#pragma once
 
 #include <cassert>
 #include <cstdio>
@@ -38,5 +37,3 @@
 				abort(); \
 			} \
 	} while(0)
-
-#endif /* LIZARDFS_UTILS_ASSERTS_H_ */

--- a/utils/configuration.h
+++ b/utils/configuration.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_UTILS_CONFIGURATION_H_
-#define LIZARDFS_UTILS_CONFIGURATION_H_
+#pragma once
 
 #include <signal.h>
 #include <stdlib.h>
@@ -62,5 +61,3 @@ private:
 		}
 	}
 };
-
-#endif /* LIZARDFS_UTILS_CONFIGURATION_H_ */

--- a/utils/data_generator.h
+++ b/utils/data_generator.h
@@ -1,5 +1,4 @@
-#ifndef LIZARDFS_UTILS_DATA_GENERATOR_H_
-#define LIZARDFS_UTILS_DATA_GENERATOR_H_
+#pragma once
 
 #include <endian.h>
 #include <fcntl.h>
@@ -140,6 +139,3 @@ protected:
 		}
 	}
 };
-
-
-#endif /* LIZARDFS_UTILS_DATA_GENERATOR_H_ */


### PR DESCRIPTION
Due to opening for external libraries, possible future code restructuring in order to avoid possible name clashes, need for maintaining coherent naming scheme, reduce code overhead I open request for migrating include guards from 
# ifndef FILE_NAME_H
# define FILE_NAME_H

...
# endif

to
# pragma once

The construct is not standarized by ISO, but de-factor mature industry standard.
For unsupporting compilers the construct can be easily substituted.
