### PR TITLE
tests: Change timeout to 3h in big files test from SystemTestingSuite

### DIFF
--- a/tests/test_suites/SanityChecks/test_write_and_read.sh
+++ b/tests/test_suites/SanityChecks/test_write_and_read.sh
@@ -1,3 +1,5 @@
+timeout_set 60 seconds
+
 CHUNKSERVERS=2 \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info

--- a/tests/test_suites/SystemTestingSuite/test_big_files.sh
+++ b/tests/test_suites/SystemTestingSuite/test_big_files.sh
@@ -1,4 +1,4 @@
-timeout_set 2 hours
+timeout_set 3 hours
 
 CHUNKSERVERS=3 \
 	MOUNTS=2 \


### PR DESCRIPTION
Setting this timeout to 3h allows this test to pass when slow hard drive is used.
3 hours timeout means that this test will pass when write speed of disk is greater than 3.8MB/s.
