### PR TITLE
tests: Increase timeouts in write-and-read and big files tests

### DIFF
--- a/tests/test_suites/SanityChecks/test_write_and_read.sh
+++ b/tests/test_suites/SanityChecks/test_write_and_read.sh
@@ -1,3 +1,5 @@
+timeout_set 60 seconds
+
 CHUNKSERVERS=2 \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info

--- a/tests/test_suites/SystemTestingSuite/test_big_files.sh
+++ b/tests/test_suites/SystemTestingSuite/test_big_files.sh
@@ -1,4 +1,4 @@
-timeout_set 2 hours
+timeout_set 3 hours
 
 CHUNKSERVERS=3 \
 	MOUNTS=2 \


### PR DESCRIPTION
Increasing timeout allows these tests to pass when slow hard drive is used.
