### PR TITLE
tests: Add valgrind support

### DIFF
--- a/tests/test_suites/SanityChecks/test_write_and_read_with_valgrind.sh
+++ b/tests/test_suites/SanityChecks/test_write_and_read_with_valgrind.sh
@@ -1,0 +1,3 @@
+enable_valgrind
+
+source test_suites/SanityChecks/test_write_and_read.sh

--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -12,6 +12,7 @@ fi
 : ${ERROR_FILE:=}
 : ${RAMDISK_DIR:=/mnt/ramdisk}
 : ${TEST_OUTPUT_DIR:=$TEMP_DIR}
+: ${USE_VALGRIND:=}
 
 # This has to be an absolute path!
 TEMP_DIR=$(readlink -m "$TEMP_DIR")
@@ -52,7 +53,7 @@ check_configuration() {
 		fi
 	done
 
-	if ! touch "$TEST_OUTPUT_DIR/$(unique_file)"; then
+	if [[ ! -w ${TEST_OUTPUT_DIR} ]]; then
 		test_fail "Configuration error, cannot create files in $TEST_OUTPUT_DIR"
 	fi
 

--- a/tests/tools/test_main.sh
+++ b/tests/tools/test_main.sh
@@ -1,4 +1,14 @@
 set -eu
+
+# Enable alias expansion and clear inherited aliases.
+unalias -a
+shopt -s expand_aliases
+
+command_prefix=
+for i in mfsmaster mfschunkserver mfsmount; do
+	alias $i="\${command_prefix} $i"
+done
+
 . tools/config.sh # This has to be the first one
 . tools/assert.sh
 . tools/lizardfs.sh
@@ -7,3 +17,4 @@ set -eu
 . tools/system.sh
 . tools/test.sh
 . tools/timeout.sh
+. tools/valgrind.sh

--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -1,20 +1,30 @@
-DEFAULT_TEST_TIMEOUT="30 seconds"
-
 timeout_killer_thread() {
 	while ! test_frozen; do
 		sleep 1
 		if test_frozen; then
 			return
 		fi
-		end_ts=$(cat "$test_timeout_end_ts_file") || true
-		now_ts=$(date +%s)
-		if [[ -z $end_ts ]]; then
+
+		local multiplier=$(cat "$test_timeout_multiplier_file")
+		local begin_ts=$(cat "$test_timeout_begin_ts_file") || true
+		local value_string=$(cat "$test_timeout_value_file") || true
+		local value=$(($(date +%s -d "$value_string") - $(date +%s)))
+		local now_ts=$(date +%s)
+
+		if [[ -z $begin_ts || -z $value_string || -z $multiplier ]]; then
 			# A race with timeout_set occured (it truncates the endTS file and then writes it)
 			# or a race with test_cleanup (test_timeout_end_ts_file has just been removed)
 			continue
 		fi
+
+		local end_ts=$(($begin_ts + $value * $multiplier))
+
 		if (( now_ts >= end_ts )); then
-			test_add_failure "Test timed out ($(cat "$test_timeout_value_file"))"
+			if (( multiplier != 1 )); then
+				test_add_failure "Test timed out (${multiplier} * ${value_string})"
+			else
+				test_add_failure "Test timed out (${value_string})"
+			fi
 			test_freeze_result
 			killall -9 -u $(whoami)
 		fi
@@ -22,9 +32,14 @@ timeout_killer_thread() {
 }
 
 timeout_init() {
-	test_timeout_end_ts_file="$TEMP_DIR/$(unique_file)_timeout_endTS.txt"
+	test_timeout_begin_ts_file="$TEMP_DIR/$(unique_file)_timeout_beginTS.txt"
+	test_timeout_multiplier_file="$TEMP_DIR/$(unique_file)_timeout_multiplier.txt"
 	test_timeout_value_file="$TEMP_DIR/$(unique_file)_timeout_value.txt"
-	timeout_set "$DEFAULT_TEST_TIMEOUT"
+
+	# default timeout values
+	timeout_set "30 seconds"
+	timeout_set_multiplier 1
+
 	# Parentheses below are needed to make 'wait' command work in tests.
 	# They make the killer thread to be a job owned by a temporary subshell, not ours
 	( timeout_killer_thread & )
@@ -32,5 +47,9 @@ timeout_init() {
 
 timeout_set() {
 	echo "$*" > "$test_timeout_value_file"
-	date +%s -d "$*" > "$test_timeout_end_ts_file"
+	date +%s > "$test_timeout_begin_ts_file"
+}
+
+timeout_set_multiplier() {
+	echo "$1" > "$test_timeout_multiplier_file"
 }

--- a/tests/tools/valgrind.sh
+++ b/tests/tools/valgrind.sh
@@ -1,0 +1,20 @@
+# Not enabled yet.
+valgrind_enabled=
+
+# Enables valgrind, can be called at the beginning of a test case.
+enable_valgrind () {
+	if ! is_program_installed valgrind; then
+		test_fail "valgrind not installed"
+	fi
+	if [[ -z $valgrind_enabled ]]; then
+		valgrind_enabled=1
+
+		# Valgrind error messages will be written here.
+		valgrind_log="${ERROR_DIR}/valgrind_%p.log"
+		valgrind_command="valgrind -q --leak-check=full --log-file=${valgrind_log}"
+
+		echo --- valgrind enabled in this test case ---
+		command_prefix="${valgrind_command} ${command_prefix}"
+		timeout_set_multiplier 5  # some tests need so big one
+	fi
+}


### PR DESCRIPTION
Add support for running tests under valgrind and reporting
valgrind-detected errors.

Allow forcing valgrind on arbitrary tests by setting USE_VALGRIND=1.

Add new 'test_write_and_read_with_valgrind' test case, which runs
the usual 'test_write_and_read' under valgrind.
