### PR TITLE
mount: Fix bug in writing data to chunkservers

### DIFF
--- a/src/common/multi_buffer_writer.cc
+++ b/src/common/multi_buffer_writer.cc
@@ -24,6 +24,7 @@ ssize_t MultiBufferWriter::writeTo(int fd) {
 			buffersCompletelySent_++;
 		} else {
 			nextBuffer.iov_base = (uint8_t*)nextBuffer.iov_base + bytesToBeRemovedFromIovec;
+			nextBuffer.iov_len -= bytesToBeRemovedFromIovec;
 			bytesToBeRemovedFromIovec = 0;
 		}
 	}


### PR DESCRIPTION
Some tests indicatied, that the data is corrupted after writing it
to LizardFS. Indeed, there was a bug in the MultiBufferWriter class.
