### PR TITLE
tests: Fix bugs in test_compilation_and_rsync

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -13,7 +13,7 @@ To prepare the testing environment safely, please use the following script:
 
 What 'setup_machine.sh' does?
  -  Creates a new user - 'lizardfstest' - on the machine;
- -  Grants this user permissions to mount fuse filesystems and runs
+ -  Grants this user permissions to mount fuse filesystems and to run
         '/bin/sh -c echo 1 > /proc/sys/vm/drop_caches' as a root;
  -  Grants everyone permissions to run processes as lizardfstests using
         'sudo -u lizardfstest' without any authentication;
@@ -35,6 +35,15 @@ There should be about 60 GB of disk space available for the tests.
 At least three directories have to be provided in order to run some of the test cases.
 Remember that user 'lizardfstest' needs permissions to write files in these
 directories. All the contents of these directories will be erased during tests.
+
+The tests need to know which binaries should be tested. The default location is
+/var/lib/lizardfstest/local and this means eg. that the master server will run code
+from the /var/lib/lizardfstest/local/sbin/mfsmaster file. You can change this
+default directory by adding an entry like this to /etc/lizardfs_tests.conf file:
+
+    : ${LIZARDFS_ROOT:=/home/you/local}
+
+Make sure that the user lizardfstest is able to read files from this directory.
 
 How to compile the tests?
 =========================

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -33,7 +33,7 @@ fi
 cd "$(dirname "$0")"
 stop_tests
 test_script="source tools/test_main.sh; source '$1'; test_end"
-nice nice sudo -Eu lizardfstest bash -c "$test_script"
+nice nice sudo -HEu lizardfstest bash -c "$test_script"
 status=$?
 stop_tests
 exit $status

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -29,6 +29,13 @@ if ! getent passwd lizardfstest > /dev/null; then
 	usermod -a -G fuse lizardfstest
 fi
 
+echo Create home directory /var/lib/lizardfstest
+if [[ ! -d /var/lib/lizardfstest ]]; then
+	mkdir -p /var/lib/lizardfstest
+	chown lizardfstest:lizardfstest /var/lib/lizardfstest
+	chmod 755 /var/lib/lizardfstest
+fi
+
 echo Prepare sudo configuration
 if ! [[ -d /etc/sudoers.d ]]; then
 	# Sudo is not installed bydefault on Debian machines
@@ -57,7 +64,7 @@ if ! [[ -f /etc/lizardfs_tests.conf ]]; then
 	cat >/etc/lizardfs_tests.conf <<-'END'
 		# : ${TEMP_DIR:=/tmp/LizardFS-autotests}
 		# : ${LIZARDFS_DISKS:="/mnt/hd1 /mnt/hd2 /mnt/hd3"}
-		# : ${LIZARDFS_ROOT:=$HOME/local}
+		# : ${LIZARDFS_ROOT:=/home/<some_user>/local}
 		# : ${FIRST_PORT_TO_USE:=25000}
 	END
 fi

--- a/tests/test_suites/SystemTestingSuite/test_compilation_and_rsync.sh
+++ b/tests/test_suites/SystemTestingSuite/test_compilation_and_rsync.sh
@@ -28,4 +28,6 @@ for goal in 1 2 3; do
 	mfssetgoal "$goal" "goal_$goal"
 	test_worker "goal_$goal" &
 done
-wait
+wait %1
+wait %2
+wait %3


### PR DESCRIPTION
This test suffered from two problems:
- git was failing beacuse it couldn't access configuration in /var/lib/jenkins
  directory using lizardfstest UID. I've added -H option to sudo to properly
  set the HOME environmental variable when running tests.
- using 'wait' instead of 'wait <jobspec>' wasn't able to generate a failure
  visible for Jenkins; vide man bash: "If n is not given, all currently active
  child processes are waited for, and the return status is zero."
