### PR TITLE
tests: Use ramdisk in all SanityChecks

### DIFF
--- a/tests/test_suites/SanityChecks/test_chunk_replication.sh
+++ b/tests/test_suites/SanityChecks/test_chunk_replication.sh
@@ -1,6 +1,7 @@
 timeout_set 90 seconds
 
 CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	MASTER_EXTRA_CONFIG="CHUNKS_LOOP_TIME = 1|REPLICATIONS_DELAY_INIT = 0" \
 	setup_local_empty_lizardfs info

--- a/tests/test_suites/SanityChecks/test_descriptors_leak_check.sh
+++ b/tests/test_suites/SanityChecks/test_descriptors_leak_check.sh
@@ -1,6 +1,6 @@
 CHUNKSERVERS=1 \
 	DISK_PER_CHUNKSERVER=1 \
-	USE_RAMDISK="yes" \
+	USE_RAMDISK=YES \
 	setup_local_empty_lizardfs info
 
 max_files=100

--- a/tests/test_suites/SanityChecks/test_goals.sh
+++ b/tests/test_suites/SanityChecks/test_goals.sh
@@ -1,4 +1,5 @@
 CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info
 

--- a/tests/test_suites/SanityChecks/test_set_get_goal.sh
+++ b/tests/test_suites/SanityChecks/test_set_get_goal.sh
@@ -1,4 +1,5 @@
 CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info
 

--- a/tests/test_suites/SanityChecks/test_sparse_file.sh
+++ b/tests/test_suites/SanityChecks/test_sparse_file.sh
@@ -1,4 +1,5 @@
 CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
 	setup_local_empty_lizardfs info
 
 file=$(mktemp -p ${info[mount0]})

--- a/tests/test_suites/SanityChecks/test_truncate.sh
+++ b/tests/test_suites/SanityChecks/test_truncate.sh
@@ -1,4 +1,5 @@
 CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info
 

--- a/tests/test_suites/SanityChecks/test_write_and_read.sh
+++ b/tests/test_suites/SanityChecks/test_write_and_read.sh
@@ -1,6 +1,7 @@
 timeout_set 60 seconds
 
 CHUNKSERVERS=2 \
+	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
 	setup_local_empty_lizardfs info
 


### PR DESCRIPTION
This will speed up SanityChecks, and will allow us to extend our CI
by using virtual machines for SanityChecks.
