### PR TITLE
tests: Fix creating image files in setup_machine.sh

### DIFF
--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -94,11 +94,7 @@ if ! grep lizardfstest_loop /etc/fstab >/dev/null; then
 		# Create image file
 		image="$disk/lizardfstest_images/image_$i"
 		truncate -s 1G "$image"
-		# Create ext4 filesystem in the file
-		dev=$(losetup -f)
-		losetup "$dev" "$image"
-		mkfs.ext4 -q "$dev"
-		losetup -d "$dev"
+		mkfs.ext4 -Fq "$image"
 		# Add it to fstab
 		echo "$(readlink -m "$image") /mnt/lizardfstest_loop_$i  ext4  loop" >> /etc/fstab
 		mkdir -p /mnt/lizardfstest_loop_$i


### PR DESCRIPTION
There were some problems with the setup_machine.sh script
when trying to call losetup -d on some machines. This commit
modifies the script so that it no longer uses losetup to create
disk images.
