### PR TITLE
tests: Remove disk lock files during cleanup

### DIFF
--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -94,6 +94,7 @@ test_cleanup() {
 	# Clean the disks used by chunkservers
 	for d in $LIZARDFS_DISKS $LIZARDFS_LOOP_DISKS; do
 		rm -rf "$d"/[0-9A-F][0-9A-F]
+		rm -f "$d"/.lock
 	done
 }
 


### PR DESCRIPTION
Remove lock files created in disk directories by the chunkservers.
