### PR TITLE
tests: Add messages from syslog to the test's output

### DIFF
--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -48,12 +48,16 @@ nice nice sudo -HEu lizardfstest bash -c "source tools/test_main.sh; test_cleanu
 stop_tests # Kill processes left by cleanup
 
 nice nice sudo -HEu lizardfstest bash -c "chmod -Rf a+rwX ${ERROR_DIR}"
-for log_file_name in `ls "${ERROR_DIR}"` ; do
-	log_file="${ERROR_DIR}/${log_file_name}"
+for log_file in "$ERROR_DIR"/* ; do
+	log_file_name=$(basename "$log_file")
 	if [[ -s ${log_file} ]]; then
 		status=1
-		echo "Error in ${log_file_name}" | tee "${ERROR_FILE}"
-		cat "${log_file}"
+		if [[ $log_file_name != syslog.log ]]; then
+			# Do not inform users that there is nonempty syslog
+			# It is always nonempty if the test failed
+			echo "Error in ${log_file_name}" | tee "${ERROR_FILE}"
+			cat "${log_file}"
+		fi
 		if [[ $TEST_OUTPUT_DIR ]]; then
 			cp "${log_file}" "$TEST_OUTPUT_DIR/$(date '+%F_%T')__$(basename -s .sh $1)__${log_file_name}"
 		fi

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -28,8 +28,13 @@ set -eux
 echo ; echo Add user lizardfstest
 if ! getent passwd lizardfstest > /dev/null; then
 	useradd --system --user-group --home /var/lib/lizardfstest lizardfstest
-	usermod -a -G fuse lizardfstest
 fi
+if ! groups lizardfstest | grep -w fuse > /dev/null; then
+	usermod -a -G fuse lizardfstest # allow this user to mount fuse filesystem
+fi
+if ! groups lizardfstest | grep -w adm > /dev/null; then
+	usermod -a -G adm lizardfstest # allow this user to read files from /var/log
+fi	 
 
 echo ; echo Create home directory /var/lib/lizardfstest
 if [[ ! -d /var/lib/lizardfstest ]]; then

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -43,16 +43,18 @@ test_end() {
 	{ pkill -TERM memcheck &> /dev/null && sleep 3; } || true
 	test_freeze_result
 	local errors=$(cat "$test_result_file")
-	# Disable error checking (we want to be able to return non-zero status) and end the test
-	trap - ERR
-	set +eE
-	[[ -z $errors ]] # This sets the exit status to non-zero if there are errors
-	exit
+	if [[ $errors ]]; then
+		exit 1
+	else
+		# Remove syslog.log from ERROR_DIR, because it would cause the test to fail
+		rm -f "$ERROR_DIR/syslog.log"
+	fi
 }
 
 # Do not run directly in test cases
 # This should be called at the very beginning of a test
 test_begin() {
+	( tail -n0 -f /var/log/syslog | stdbuf -oL tee "$ERROR_DIR/syslog.log" & )
 	test_result_file="$TEMP_DIR/$(unique_file)_results.txt"
 	test_end_file=$test_result_file.end
 	check_configuration


### PR DESCRIPTION
All LizardFS modules put their logs in the syslog. After the test fails
one can find a lot of useful information there. This change does two things:
- adds everything from syslog to the standard output of the test
- publishes messages from syslog in TEST_OUTPUT_DIR (if provided)
