### PR TITLE
tests: Enable valgrind only if USE_VALGRIND=YES

### DIFF
--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -13,7 +13,7 @@ fi
 : ${ERROR_FILE:=}
 : ${RAMDISK_DIR:=/mnt/ramdisk}
 : ${TEST_OUTPUT_DIR:=$TEMP_DIR}
-: ${USE_VALGRIND:=}
+: ${USE_VALGRIND:=NO}
 
 # This has to be an absolute path!
 TEMP_DIR=$(readlink -m "$TEMP_DIR")

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -61,7 +61,7 @@ test_begin() {
 	trap 'trap - ERR; set +eEu; catch_error_ "$BASH_SOURCE" "$LINENO" "$FUNCNAME"; exit 1' ERR
 	set -E
 	timeout_init
-	if [[ ${USE_VALGRIND} ]]; then
+	if [[ ${USE_VALGRIND^^} == YES ]]; then
 		enable_valgrind
 	fi
 }


### PR DESCRIPTION
The tests did enable valgrind when the environmental variable
USE_VALGIND was nonempty. This commit adds a requirement that
this variable is nonempty and equal to YES (or yes, Yes, etc.).
This would make it easier to add a combo box in Jenkins with
two possible USE_VALGRIND values: YES and NO.
