### PR TITLE
tests: Fix bug in test_end

### DIFF
--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -48,6 +48,7 @@ test_end() {
 	else
 		# Remove syslog.log from ERROR_DIR, because it would cause the test to fail
 		rm -f "$ERROR_DIR/syslog.log"
+		exit 0
 	fi
 }
 


### PR DESCRIPTION
test_end should always call exit, to make it possible to end tests
just by calling test_end.
