### PR TITLE
utils: Add inode information to file-validate's output

### DIFF
--- a/utils/data_generator.h
+++ b/utils/data_generator.h
@@ -69,11 +69,13 @@ public:
 		uint64_t expectedSize;
 		if(read(fd, &expectedSize, sizeof(expectedSize)) != sizeof(expectedSize)) {
 			// The file if too short, so the first bytes are corrupted.
-			throw std::length_error("file too short (" + std::to_string(actualSize) + " bytes)");
+			throw std::length_error("(inode " + std::to_string(fileInformation.st_ino) + ")"
+					" file too short (" + std::to_string(actualSize) + " bytes)");
 		}
 		expectedSize = be64toh(expectedSize);
 		if (expectedSize != (size_t)fileInformation.st_size) {
-			error = "file should be " + std::to_string(expectedSize) +
+			error = "(inode " + std::to_string(fileInformation.st_ino) + ")"
+					" file should be " + std::to_string(expectedSize) +
 					" bytes long, but is " + std::to_string(actualSize) + " bytes long\n";
 		}
 
@@ -100,7 +102,8 @@ public:
 			for (size_t i = 0; i < bytesToRead; ++i) {
 				if (actualBuffer[i] != properBuffer[i]) {
 					std::stringstream ss;
-					ss << "data mismatch at offset " << i << ". Expected/actual:\n";
+					ss << "(inode " << fileInformation.st_ino << ")"
+							<< " data mismatch at offset " << i << ". Expected/actual:\n";
 					for (size_t j = i; j < bytesToRead && j < i + 32; ++j) {
 						ss << std::hex << std::setfill('0') << std::setw(2)
 								<< static_cast<int>(static_cast<unsigned char>(properBuffer[j]))


### PR DESCRIPTION
When there are any problems with the LizardFS filesystem all the
files are identified by their inodes in the syslog. Adding inode
information to the output of file-validate will make it easier to
match information about corruptes files with the errors in syslog.
