### PR TITLE
tests: Improve assertion failure messages

### DIFF
--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -105,11 +105,10 @@ catch_error_() {
 	local file=$1
 	local line=$2
 	local funcname=$3
-	local line_contents=$(sed -n "${line}s/^[[:blank:]]*//p" "$file")
 	if [[ $funcname ]]; then
 		local location="in function $funcname ($file:$line)"
 	else
 		local location="($file:$line)"
 	fi
-	test_add_failure "Command '$line_contents' failed $location"
+	test_add_failure "Command '$(get_source_line "$file" "$line")' failed $location"
 }


### PR DESCRIPTION
Consider the following test:

  a=500
  b=90
  expect_less_or_equal $a $b

This code produced the following, not very user-friendly error:

  FAILURE [2014-02-14 13:04:17] Expected: '500' <= '90'

This commit introduces more descriptive messages, ie:

  FAILURE [2014-02-14 13:04:47] Assertion 'expect_less_or_equal $a $b' failed
  Expected: '500' <= '90'
  Location: test_assert.sh:3

If the custom message is used, eg:

  MESSAGE="Checking simple arithmetics" expect_less_or_equal $a $b

the error message will look like this:

  FAILURE [2014-02-14 13:04:47] Checking simple arithmetics: Assertion 'expect_less_or_equal $a $b' failed
  Expected: '500' <= '90'
  Location: test_assert.sh:3
