### PR TITLE
chunkserver: Fix overflow in charts

### DIFF
--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -132,8 +132,8 @@ static struct itimerval it_set;
 
 void chartsdata_refresh(void) {
 	uint64_t data[CHARTS];
-	uint64_t bin,bout;
-	uint32_t i,opr,opw,dbr,dbw,dopr,dopw,repl;
+	uint64_t bin,bout,dbr,dbw;
+	uint32_t i,opr,opw,dopr,dopw,repl;
 	uint32_t op_cr,op_de,op_ve,op_du,op_tr,op_dt,op_te;
 	uint32_t csservjobs,masterjobs;
 	struct itimerval uc,pc;

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -268,8 +268,8 @@ static uint64_t stats_bytesr = 0;
 static uint64_t stats_bytesw = 0;
 static uint32_t stats_opr = 0;
 static uint32_t stats_opw = 0;
-static uint32_t stats_databytesr = 0;
-static uint32_t stats_databytesw = 0;
+static uint64_t stats_databytesr = 0;
+static uint64_t stats_databytesw = 0;
 static uint32_t stats_dataopr = 0;
 static uint32_t stats_dataopw = 0;
 static uint64_t stats_rtime = 0;
@@ -491,7 +491,7 @@ int hdd_spacechanged(void) {
 	return result;
 }
 
-void hdd_stats(uint64_t *br,uint64_t *bw,uint32_t *opr,uint32_t *opw,uint32_t *dbr,uint32_t *dbw,uint32_t *dopr,uint32_t *dopw,uint64_t *rtime,uint64_t *wtime) {
+void hdd_stats(uint64_t *br,uint64_t *bw,uint32_t *opr,uint32_t *opw,uint64_t *dbr,uint64_t *dbw,uint32_t *dopr,uint32_t *dopw,uint64_t *rtime,uint64_t *wtime) {
 	zassert(pthread_mutex_lock(&statslock));
 	*br = stats_bytesr;
 	*bw = stats_bytesw;

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -22,7 +22,7 @@
 
 #include "common/MFSCommunication.h"
 
-void hdd_stats(uint64_t *br,uint64_t *bw,uint32_t *opr,uint32_t *opw,uint32_t *dbr,uint32_t *dbw,uint32_t *dopr,uint32_t *dopw,uint64_t *rtime,uint64_t *wtime);
+void hdd_stats(uint64_t *br,uint64_t *bw,uint32_t *opr,uint32_t *opw,uint64_t *dbr,uint64_t *dbw,uint32_t *dopr,uint32_t *dopw,uint64_t *rtime,uint64_t *wtime);
 void hdd_op_stats(uint32_t *op_create,uint32_t *op_delete,uint32_t *op_version,uint32_t *op_duplicate,uint32_t *op_truncate,uint32_t *op_duptrunc,uint32_t *op_test);
 uint32_t hdd_errorcounter(void);
 


### PR DESCRIPTION
The value of "bytes read" in chunkserver's charts was overflowing
at 70 MB/s. This commit fixes this problem.
