### PR TITLE
tests: Add possibility to generate a code coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 set(CMAKE_CXX_FLAGS "-std=c++0x -Wall -Wextra -pedantic -fwrapv")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_COVERAGE "-O0 -g --coverage")
 
 add_definitions(-D_LARGEFILE_SOURCE)
 add_definitions(-D_FILE_OFFSET_BITS=64)

--- a/utils/coverage.sh
+++ b/utils/coverage.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+appname=$0
+command=$1
+builddir=$2
+shift 2
+
+usage() {
+	{
+		echo "Usage:"
+		echo "$appname prepare <build-dir>"
+		echo "    Prepares a CMake build directory to run tests with will generate"
+		echo "    a code coverage report. This is needed, because LizardFS tests are"
+		echo "    run with a different UID than the user who builds sources."
+		echo "$appname generate-html <build-dir> <out-dir>"
+		echo "    Generates a HTML code coverage report from the data collected during tests"
+	} >&2
+	exit 1
+}
+
+if [[ ! -f "$builddir/CMakeCache.txt" ]]; then
+	usage
+fi
+
+if [[ $command == prepare ]]; then
+	set -eu
+	find "$builddir" -type d | xargs chmod a+w
+	find "$builddir" -name '*.gcda' | xargs rm -f
+elif [[ $command == generate-html ]]; then
+	outdir=$1
+	set -eu
+	mkdir -p "$outdir"
+	lcov --capture --directory . --output-file cov.raw
+	lcov --remove cov.raw '/usr/*' '*/external/*' '*/tests/*' '*/utils/*' '*/devtools/*' -o cov.info
+	genhtml cov.info --output-directory "$outdir" --no-branch-coverage
+	rm -f cov.raw cov.info
+else
+	usage
+fi


### PR DESCRIPTION
To generate such a report:
- Build sources with`CMAKE_BUILD_TYPE=Coverage` and install the binaries.
- Run the script: `coverage.sh prepare <build-dir>` to make the files in the build
  dir accessible by processes running during tests.
- Run the tests with `GENTLY_KILL=1` environmental variable. This will ensure
  that all the binaries dump coverage data on exit.
- Generate a HTML report: `coverage.sh generate-html <build-dir> <out-dir>`.
