### PR TITLE
tests: Increase timeouts for tests using vagrind

### DIFF
--- a/tests/test_suites/SanityChecks/test_descriptors_leak_check.sh
+++ b/tests/test_suites/SanityChecks/test_descriptors_leak_check.sh
@@ -3,7 +3,6 @@ CHUNKSERVERS=1 \
 	USE_RAMDISK=YES \
 	setup_local_empty_lizardfs info
 
-timeout_set_multiplier 10
 max_files=100
 max_open_descriptors=10
 time_limit=15

--- a/tests/tools/valgrind.sh
+++ b/tests/tools/valgrind.sh
@@ -15,6 +15,6 @@ enable_valgrind () {
 
 		echo --- valgrind enabled in this test case ---
 		command_prefix="${valgrind_command} ${command_prefix}"
-		timeout_set_multiplier 5  # some tests need so big one
+		timeout_set_multiplier 10 # some tests need so big one
 	fi
 }


### PR DESCRIPTION
Some tests (eg. test_write_and_read) indicate that the time needed to
run a test using valgring is rougly 10 times bigger than the time when
valgrind is not used. Increase the timeout multiplier in valgrind.sh
from 5 to 10 to address this.
