### PR TITLE
master, chunkserver, metalogger: Add isalive command

### DIFF
--- a/doc/mfschunkserver.8
+++ b/doc/mfschunkserver.8
@@ -62,7 +62,7 @@ run in foreground, don't daemonize
 how long to wait for lockfile (default is 60 seconds)
 .TP
 \fIACTION\fP
-is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP or \fBkill\fP. Default action is
+is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP, \fBisalive\fP or \fBkill\fP. Default action is
 \fBrestart\fP unless \fB\-s\fP (stop) or \fB\-f\fP (start) option is given.
 Note that \fB\-s\fP and \fB\-f\fP options are deprecated, likely to disappear
 and \fIACTION\fP parameter to become obligatory in MooseFS 1.7.

--- a/doc/mfsmaster.8
+++ b/doc/mfsmaster.8
@@ -53,7 +53,7 @@ run in foreground, don't daemonize
 how long to wait for lockfile (default is 60 seconds)
 .TP
 \fIACTION\fP
-is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP or \fBkill\fP. Default action is
+is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP, \fBisalive\fP or \fBkill\fP. Default action is
 \fBrestart\fP unless \fB\-s\fP (stop) or \fB\-f\fP (start) option is given.
 Note that \fB\-s\fP and \fB\-f\fP options are deprecated, likely to disappear
 and \fIACTION\fP parameter to become obligatory in MooseFS 1.7.

--- a/doc/mfsmetalogger.8
+++ b/doc/mfsmetalogger.8
@@ -56,7 +56,7 @@ run in foreground, don't daemonize
 how long to wait for lockfile (default is 60 seconds)
 .TP
 \fIACTION\fP
-is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP or \fBkill\fP. Default action is
+is the one of \fBstart\fP, \fBstop\fP, \fBrestart\fP, \fBreload\fP, \fBtest\fP, \fBisalive\fP or \fBkill\fP. Default action is
 \fBrestart\fP unless \fB\-s\fP (stop) or \fB\-f\fP (start) option is given.
 Note that \fB\-s\fP and \fB\-f\fP options are deprecated, likely to disappear
 and \fIACTION\fP parameter to become obligatory in MooseFS 1.7.

--- a/src/common/main.h
+++ b/src/common/main.h
@@ -21,6 +21,10 @@
 #include <poll.h>
 #include <inttypes.h>
 
+#define LIZARDFS_EXIT_STATUS_SUCCESS 0
+#define LIZARDFS_EXIT_STATUS_NOT_ALIVE 1
+#define LIZARDFS_EXIT_STATUS_ERROR 2
+
 #define TIMEMODE_SKIP_LATE 0
 #define TIMEMODE_RUN_LATE 1
 

--- a/tests/test_suites/SystemTestingSuite/test_exit_status.sh
+++ b/tests/test_suites/SystemTestingSuite/test_exit_status.sh
@@ -1,0 +1,36 @@
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="mfscachemode=NEVER" \
+	setup_local_empty_lizardfs info
+
+get_status() {
+	"$@" >&2 | true
+	echo ${PIPESTATUS[0]}
+}
+
+# Test exit statuses of the chunkserver
+expect_less_or_equal 2 $(get_status mfschunkserver -c "$TEMP_DIR/nonexistent_file" start)
+expect_less_or_equal 2 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" wrongusage)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" isalive)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" restart)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" isalive)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" stop)
+expect_equals 1 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" isalive)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" start)
+expect_equals 0 $(get_status mfschunkserver -c "${info[chunkserver0_config]}" isalive)
+
+# Test exit statuses of the master server
+expect_less_or_equal 2 $(get_status lizardfs_master_daemon some_typo)
+expect_less_or_equal 2 $(get_status lizardfs_master_daemon -@ restart)
+expect_equals 0 $(get_status lizardfs_master_daemon isalive)
+expect_equals 0 $(get_status lizardfs_master_daemon restart)
+expect_equals 0 $(get_status lizardfs_master_daemon isalive)
+expect_equals 0 $(get_status lizardfs_master_daemon stop)
+expect_equals 1 $(get_status lizardfs_master_daemon isalive)
+mv "${info[master_data_path]}/metadata.mfs" "${info[master_data_path]}/metadata.mfs.xxx"
+expect_less_or_equal 2 $(get_status lizardfs_master_daemon start)
+expect_less_or_equal 2 $(get_status lizardfs_master_daemon restart)
+expect_equals 1 $(get_status lizardfs_master_daemon isalive)
+mv "${info[master_data_path]}/metadata.mfs.xxx" "${info[master_data_path]}/metadata.mfs"
+expect_equals 0 $(get_status lizardfs_master_daemon start)
+expect_equals 0 $(get_status lizardfs_master_daemon isalive)

--- a/tests/tools/lizardfs.sh
+++ b/tests/tools/lizardfs.sh
@@ -74,7 +74,8 @@ create_mfsmaster_cfg() {
 }
 
 lizardfs_master_daemon() {
-	mfsmaster -c "${lizardfs_info[master_cfg]}" "$1"
+	mfsmaster -c "${lizardfs_info[master_cfg]}" "$1" | cat
+	return ${PIPESTATUS[0]}
 }
 
 run_master_server() {


### PR DESCRIPTION
This commit introduces a new command isalive which can be use to test
if a daemon (mfsmaster, mfsmetalogger of mfschunkserser) if running.
The exit status of this command is as follows:
- 0 if the daemon is running
- 1 if the daemon is not running
- other if an error occured during the check

The exit status 1 is reserved to the isalive command and is used only
to indicate that the daemon is down. No other invocation (including
wrong usage, eg. mfsmaster isaliv) will exit with the status of 1.
