### PR TITLE
common: Add messages for handling global IO limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(ENABLE_LIGHTMFS      "Enable light version of LizardFS"                  
 option(ENABLE_DEBIAN_PATHS  "Enable Debian-style install paths"                       OFF)
 option(ENABLE_UTILS         "Enable building additional binaries used e.g. in tests"  OFF)
 option(ENABLE_TESTS         "Enable building unit and functional tests"               OFF)
+option(THROW_INSTEAD_OF_ABORT   "Throw std::exception instead of calling abort"       OFF)
 
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
@@ -41,9 +42,17 @@ message(STATUS "ENABLE_LIGHTMFS: ${ENABLE_LIGHTMFS}")
 message(STATUS "ENABLE_DEBIAN_PATHS: ${ENABLE_DEBIAN_PATHS}")
 message(STATUS "ENABLE_UTILS: ${ENABLE_UTILS}")
 message(STATUS "ENABLE_TESTS: ${ENABLE_TESTS}")
+message(STATUS "THROW_INSTEAD_OF_ABORT: ${THROW_INSTEAD_OF_ABORT}")
 
 ## All the environment tests (libs, includes, etc.) live here:
 include(EnvTests.cmake)
+
+if(ENABLE_TESTS AND NOT THROW_INSTEAD_OF_ABORT)
+  message(STATUS "Tests require THROW_INSTEAD_OF_ABORT to be set to YES, changing passed value:")
+    set(THROW_INSTEAD_OF_ABORT YES)
+  message(STATUS "THROW_INSTEAD_OF_ABORT: ${THROW_INSTEAD_OF_ABORT}")
+endif()
+
 
 if(ENABLE_DEBIAN_PATHS)
   if (NOT CMAKE_INSTALL_PREFIX STREQUAL "/")
@@ -90,6 +99,11 @@ if(ENABLE_TESTS)
 endif()
 
 set(CHARTS_CSV_CHARTID_BASE 90000)
+
+if(THROW_INSTEAD_OF_ABORT)
+  add_definitions(-DTHROW_INSTEAD_OF_ABORT)
+endif()
+
 
 # Create config.h file
 set(DATA_PATH "${CMAKE_INSTALL_PREFIX}/${DATA_SUBDIR}")

--- a/src/common/MFSCommunication.h
+++ b/src/common/MFSCommunication.h
@@ -1172,6 +1172,18 @@
 #define MATOCL_CSSERV_REMOVESERV (PROTO_BASE+525)
 // N * [ version:32 ip:32 ]
 
+// 0x05F8
+#define LIZ_MATOCL_IOLIMITS_CONFIG (1000U + 528U)
+// subsystem:string groups:(vector<string>) frequency:32
+
+// 0x05F9
+#define LIZ_CLTOMA_IOLIMIT (1000U + 529U)
+/// grouplen:32 group:STRING[grouplen] wantmore:8 limit:64 usage:64
+
+// 0x05FA
+#define LIZ_MATOCL_IOLIMIT (1000U + 530U)
+/// grouplen:32 group:STRING[grouplen] limit:64
+
 // CHUNKSERVER STATS
 
 // 0x00258

--- a/src/common/cltoma_communication.h
+++ b/src/common/cltoma_communication.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "common/packet.h"
+
+namespace cltoma {
+
+namespace iolimit {
+
+inline void serialize(std::vector<uint8_t>& destination, const std::string& group, bool wantMore,
+		uint64_t currentLimit_Bps, uint64_t recentUsage_Bps) {
+	serializePacket(destination, LIZ_CLTOMA_IOLIMIT, 0, group, wantMore,
+			currentLimit_Bps, recentUsage_Bps);
+}
+
+inline void deserialize(const uint8_t* source, uint32_t sourceSize, std::string& group,
+		bool& wantMore, uint64_t& currentLimit_Bps, uint64_t& recentUsage_Bps)
+{
+	verifyPacketVersionNoHeader(source, sourceSize, 0);
+	deserializeAllPacketDataNoHeader(source, sourceSize, group, wantMore,
+			currentLimit_Bps, recentUsage_Bps);
+}
+
+} // namespace iolimit
+
+} // namespace cltoma

--- a/src/common/cltoma_communication_unittest.cc
+++ b/src/common/cltoma_communication_unittest.cc
@@ -1,0 +1,27 @@
+#include "common/cltoma_communication.h"
+
+#include <gtest/gtest.h>
+
+#include "unittests/packet.h"
+#include "unittests/inout_pair.h"
+
+TEST(CltomaCommunicationTests, IoLimitNeeds) {
+	LIZARDFS_DEFINE_INOUT_PAIR(std::string, group       , "group 123", "");
+	LIZARDFS_DEFINE_INOUT_PAIR(bool       , wantMore    , true       , false);
+	LIZARDFS_DEFINE_INOUT_PAIR(uint64_t   , currentLimit, 1234       , 0);
+	LIZARDFS_DEFINE_INOUT_PAIR(uint64_t   , recentUsage , 5678       , 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(cltoma::iolimit::serialize(buffer, groupIn, wantMoreIn,
+			currentLimitIn, recentUsageIn));
+
+	verifyHeader(buffer, LIZ_CLTOMA_IOLIMIT);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(cltoma::iolimit::deserialize(buffer.data(), buffer.size(),
+			groupOut, wantMoreOut, currentLimitOut, recentUsageOut));
+
+	LIZARDFS_VERIFY_INOUT_PAIR(group);
+	LIZARDFS_VERIFY_INOUT_PAIR(wantMore);
+	LIZARDFS_VERIFY_INOUT_PAIR(currentLimit);
+	LIZARDFS_VERIFY_INOUT_PAIR(recentUsage);
+}

--- a/src/common/massert.h
+++ b/src/common/massert.h
@@ -23,20 +23,34 @@
 #include <syslog.h>
 #include <stdlib.h>
 
+#ifdef THROW_INSTEAD_OF_ABORT
+	#include <stdexcept>
+	#include <string>
+	#define ABORT_OR_THROW (throw std::runtime_error(std::string(__FILE__ ":") + \
+			std::to_string(__LINE__)))
+#else
+	#define ABORT_OR_THROW abort()
+#endif
+
 #include "common/strerr.h"
 
-#define massert(e,msg) ((e) ? (void)0 : (fprintf(stderr,"failed assertion '%s' : %s\n",#e,(msg)),syslog(LOG_ERR,"failed assertion '%s' : %s",#e,(msg)),abort()))
-#define passert(ptr) ((ptr!=NULL) ? (void)0 : (fprintf(stderr,"out of memory: %s is NULL\n",#ptr),syslog(LOG_ERR,"out of memory: %s is NULL",#ptr),abort()))
-#define sassert(e) ((e) ? (void)0 : (fprintf(stderr,"failed assertion '%s'\n",#e),syslog(LOG_ERR,"failed assertion '%s'",#e),abort()))
+#define massert(e, msg) ((e) ? (void)0 : (fprintf(stderr, "failed assertion '%s' : %s\n", #e, \
+		(msg)), syslog(LOG_ERR, "failed assertion '%s' : %s", #e, (msg)), ABORT_OR_THROW))
+#define passert(ptr) ((ptr != NULL) ? (void)0 : (fprintf(stderr, "out of memory: %s is NULL\n", \
+		#ptr), syslog(LOG_ERR,"out of memory: %s is NULL", #ptr), ABORT_OR_THROW))
+#define sassert(e) ((e) ? (void)0 : (fprintf(stderr, "failed assertion '%s'\n", #e), \
+		syslog(LOG_ERR, "failed assertion '%s'", #e), ABORT_OR_THROW))
 #define eassert(e) if (!(e)) { \
 		const char *_mfs_errorstring = strerr(errno); \
 		syslog(LOG_ERR,"failed assertion '%s', error: %s",#e,_mfs_errorstring); \
 		fprintf(stderr,"failed assertion '%s', error: %s\n",#e,_mfs_errorstring); \
-		abort(); \
+		ABORT_OR_THROW; \
 	}
 #define zassert(e) if ((e)!=0) { \
 		const char *_mfs_errorstring = strerr(errno); \
 		syslog(LOG_ERR,"unexpected status, '%s' returned: %s",#e,_mfs_errorstring); \
 		fprintf(stderr,"unexpected status, '%s' returned: %s\n",#e,_mfs_errorstring); \
-		abort(); \
+		ABORT_OR_THROW; \
 	}
+#define mabort(msg) do { fprintf(stderr,"abort '%s'\n", msg); syslog(LOG_ERR, "abort '%s'", msg); \
+	ABORT_OR_THROW; } while (false)

--- a/src/common/matocl_communication.h
+++ b/src/common/matocl_communication.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "common/packet.h"
+
+namespace matocl {
+
+namespace iolimits_config {
+
+inline void serialize(std::vector<uint8_t>& destination, const std::string& subsystem,
+		const std::vector<std::string>& groups, uint32_t renewFrequency_us) {
+	serializePacket(destination, LIZ_MATOCL_IOLIMITS_CONFIG, 0, subsystem, groups,
+			renewFrequency_us);
+}
+
+inline void deserialize(const uint8_t* source, uint32_t sourceSize, std::string& subsystem,
+		std::vector<std::string>& groups, uint32_t& renewFrequency_us) {
+	verifyPacketVersionNoHeader(source, sourceSize, 0);
+	deserializeAllPacketDataNoHeader(source, sourceSize, subsystem, groups, renewFrequency_us);
+}
+
+} // namespace iolimits_config
+
+namespace iolimit {
+
+inline void serialize(std::vector<uint8_t>& destination, const std::string& group,
+		uint64_t limit_Bps) {
+	serializePacket(destination, LIZ_MATOCL_IOLIMIT, 0, group, limit_Bps);
+}
+
+inline void deserialize(const uint8_t* source, uint32_t sourceSize, std::string& group,
+		uint64_t& limit_Bps) {
+	verifyPacketVersionNoHeader(source, sourceSize, 0);
+	deserializeAllPacketDataNoHeader(source, sourceSize, group, limit_Bps);
+}
+
+} // namespace iolimit
+
+} // namespace matocl

--- a/src/common/matocl_communication_unitttest.cc
+++ b/src/common/matocl_communication_unitttest.cc
@@ -1,0 +1,43 @@
+#include "common/matocl_communication.h"
+
+#include <gtest/gtest.h>
+
+#include "unittests/packet.h"
+#include "unittests/inout_pair.h"
+
+TEST(MatoclCommunicationTests, IoLimitsConfig) {
+	std::vector<std::string> groups_tmp{"group 1", "group 20", "group 300"};
+
+	LIZARDFS_DEFINE_INOUT_PAIR(std::string             , subsystem, "cgroups_something", "");
+	LIZARDFS_DEFINE_INOUT_PAIR(std::vector<std::string>, groups   , groups_tmp         , {});
+	LIZARDFS_DEFINE_INOUT_PAIR(uint32_t                , frequency, 100                , 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(matocl::iolimits_config::serialize(buffer, subsystemIn, groupsIn,
+			frequencyIn));
+
+	verifyHeader(buffer, LIZ_MATOCL_IOLIMITS_CONFIG);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(matocl::iolimits_config::deserialize(buffer.data(), buffer.size(),
+			subsystemOut, groupsOut, frequencyOut));
+
+	LIZARDFS_VERIFY_INOUT_PAIR(subsystem);
+	LIZARDFS_VERIFY_INOUT_PAIR(groups);
+	LIZARDFS_VERIFY_INOUT_PAIR(frequency);
+}
+
+TEST(MatoclCommunicationTests, IoLimitAllocated) {
+	LIZARDFS_DEFINE_INOUT_PAIR(std::string, group, "group 123", "");
+	LIZARDFS_DEFINE_INOUT_PAIR(uint64_t, limit, 1234, 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(matocl::iolimit::serialize(buffer, groupIn, limitIn));
+
+	verifyHeader(buffer, LIZ_MATOCL_IOLIMIT);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(matocl::iolimit::deserialize(buffer.data(), buffer.size(),
+			groupOut, limitOut));
+
+	LIZARDFS_VERIFY_INOUT_PAIR(limit);
+	LIZARDFS_VERIFY_INOUT_PAIR(group);
+}

--- a/src/common/packet.cc
+++ b/src/common/packet.cc
@@ -1,0 +1,24 @@
+#include "common/packet.h"
+#include "common/sockets.h"
+
+void receivePacket(PacketHeader& header, std::vector<uint8_t>& data, int sock,
+		uint32_t timeout_ms) throw (Exception) {
+	sassert(data.empty());
+
+	const int32_t headerSize = serializedSize(header);
+
+	data.resize(headerSize);
+	if (tcptoread(sock, data.data(), headerSize, timeout_ms) != headerSize) {
+		tcpclose(sock);
+		throw Exception("Did not manage to receive packet header");
+	}
+
+	deserializePacketHeader(data, header);
+
+	const int32_t payloadSize = header.length;
+	data.resize(payloadSize);
+	if (tcptoread(sock, data.data(), payloadSize, timeout_ms) != payloadSize) {
+		tcpclose(sock);
+		throw Exception("Did not manage to receive packet data");
+	}
+}

--- a/src/common/serialization.h
+++ b/src/common/serialization.h
@@ -15,8 +15,11 @@ public:
 			Exception("Deserialization error: " + message) {}
 };
 
-
 // serializedSize
+
+inline uint32_t serializedSize(const bool&) {
+	return 1;
+}
 
 inline uint32_t serializedSize(const uint8_t&) {
 	return 1;
@@ -34,9 +37,36 @@ inline uint32_t serializedSize(const uint64_t&) {
 	return 8;
 }
 
+inline uint32_t serializedSize(const char& c) {
+	return serializedSize(reinterpret_cast<const uint8_t&>(c));
+}
+
+template <class T, int N>
+inline uint32_t serializedSize(const T (&array)[N]) {
+	return N * serializedSize(array[0]);
+}
+
+template<class T1, class T2>
+inline uint32_t serializedSize(const std::pair<T1, T2>& pair) {
+	return serializedSize(pair.first) + serializedSize(pair.second);
+}
+
+inline uint32_t serializedSize(const std::string& value) {
+	return serializedSize(value.size()) + serializedSize(std::string::value_type()) * value.size();
+}
+
+inline uint32_t serializedSize(const std::vector<std::string>& vector) {
+	uint32_t ret = 0;
+	ret += serializedSize(vector.size());
+	for (const auto& str : vector) {
+		ret += serializedSize(str);
+	}
+	return ret;
+}
+
 template<class T>
-inline uint32_t serializedSize(const std::vector<T>& vec) {
-	return vec.size() * serializedSize(T());
+inline uint32_t serializedSize(const std::vector<T>& vector) {
+	return vector.size() * serializedSize(T());
 }
 
 template<class T, class ... Args>
@@ -46,25 +76,68 @@ inline uint32_t serializedSize(const T& t, const Args& ... args) {
 
 // serialize for simple types
 
+// serialize bool
+inline void serialize(uint8_t** destination, const bool& value) {
+	put8bit(destination, static_cast<uint8_t>(value ? 1 : 0));
+}
+
+// serialize uint8_t
 inline void serialize(uint8_t** destination, const uint8_t& value) {
 	put8bit(destination, value);
 }
 
+// serialize uint16_t
 inline void serialize(uint8_t** destination, const uint16_t& value) {
 	put16bit(destination, value);
 }
 
+// serialize uint32_t
 inline void serialize(uint8_t** destination, const uint32_t& value) {
 	put32bit(destination, value);
 }
 
+// serialize uint64_t
 inline void serialize(uint8_t** destination, const uint64_t& value) {
 	put64bit(destination, value);
 }
 
+inline void serialize(uint8_t** destination, const char& value) {
+	serialize(destination, reinterpret_cast<const uint8_t&>(value));
+}
+
+// serialize fixed size array ("type name[number];")
+template <class T, int N>
+inline void serialize(uint8_t** destination, const T (&array)[N]) {
+	for (int i = 0; i < N; i++) {
+		serialize(destination, array[i]);
+	}
+}
+
+// serialize a pair
+template<class T1, class T2>
+inline void serialize(uint8_t** destination, const std::pair<T1, T2>& pair) {
+	serialize(destination, pair.first);
+	serialize(destination, pair.second);
+}
+
+inline void serialize(uint8_t** destination, const std::string& value) {
+	serialize(destination, value.length());
+	for (unsigned i = 0; i < value.length(); ++i) {
+		serialize(destination, value[i]);
+	}
+}
+
+inline void serialize(uint8_t** destination, const std::vector<std::string>& vector) {
+	serialize(destination, vector.size());
+	for (const auto& str : vector) {
+		serialize(destination, str);
+	}
+}
+
+// serialize a vector
 template<class T>
-inline void serialize(uint8_t** destination, const std::vector<T>& vec) {
-	for (const T& t : vec) {
+inline void serialize(uint8_t** destination, const std::vector<T>& vector) {
+	for (const T& t : vector) {
 		serialize(destination, t);
 	}
 }
@@ -86,42 +159,110 @@ inline void verifySize(const T& value, uint32_t bytesLeft) {
 
 // deserialize functions for simple types
 
+// deserialize bool
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, bool& value) {
+	verifySize(value, bytesLeftInBuffer);
+	bytesLeftInBuffer -= 1;
+	uint8_t integerValue = get8bit(source);
+	if (integerValue > 1) {
+		throw IncorrectDeserializationException("corrupted boolean value");
+	}
+	value = static_cast<bool>(integerValue);
+}
+
+// deserialize uint8_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint8_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 1;
 	value = get8bit(source);
 }
 
+// deserialize uint16_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint16_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 2;
 	value = get16bit(source);
 }
 
+// deserialize uint32_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint32_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 4;
 	value = get32bit(source);
 }
 
+// deserialize uint64_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint64_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 8;
 	value = get64bit(source);
 }
 
-template<class T>
-inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, std::vector<T>& vec) {
-	size_t sizeOfElement = serializedSize(T());
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, char& value) {
+	deserialize(source, bytesLeftInBuffer, reinterpret_cast<uint8_t&>(value));
+}
+
+// deserialize fixed size array ("type name[number];")
+template <class T, int N>
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, T (&array)[N]) {
+	for (int i = 0; i < N; i++) {
+		deserialize(source, bytesLeftInBuffer, array[i]);
+	}
+}
+
+// deserialize a pair
+template<class T1, class T2>
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
+		std::pair<T1, T2>& pair) {
+	deserialize(source, bytesLeftInBuffer, pair.first);
+	deserialize(source, bytesLeftInBuffer, pair.second);
+}
+
+// deserialize uint8_t* (as a pointer to the serialized data)
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, const uint8_t*& value) {
+	if (bytesLeftInBuffer == 0) {
+		throw IncorrectDeserializationException("unexpected end of buffer");
+	}
+	bytesLeftInBuffer = 0;
+	value = *source;
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, std::string& value) {
+	sassert(value.size() == 0);
+	uint32_t size;
+	deserialize(source, bytesLeftInBuffer, size);
+	value.resize(size);
+	for (unsigned i = 0; i < size; ++i) {
+		deserialize(source, bytesLeftInBuffer, value[i]);
+	}
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
+		std::vector<std::string>& vec) {
 	sassert(vec.size() == 0);
+	uint32_t size;
+	deserialize(source, bytesLeftInBuffer, size);
+	vec.resize(size);
+	for (unsigned i = 0; i < size; ++i) {
+		deserialize(source, bytesLeftInBuffer, vec[i]);
+	}
+}
+
+// deserialize a vector
+template<class T>
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
+		std::vector<T>& vector) {
+	size_t sizeOfElement = serializedSize(T());
+	sassert(vector.size() == 0);
 	sassert(sizeOfElement > 0);
 	if (bytesLeftInBuffer % sizeOfElement != 0) {
-		throw IncorrectDeserializationException();
+		throw IncorrectDeserializationException(
+				"vector: buffer size not divisible by element size");
 	}
 	size_t vecSize = bytesLeftInBuffer / sizeOfElement;
-	vec.resize(vecSize);
+	vector.resize(vecSize);
 	for (size_t i = 0; i < vecSize; ++i) {
-		deserialize(source, bytesLeftInBuffer, vec[i]);
+		deserialize(source, bytesLeftInBuffer, vector[i]);
 	}
 }
 

--- a/src/common/serialization_unittest.cc
+++ b/src/common/serialization_unittest.cc
@@ -1,0 +1,37 @@
+#include "common/serialization.h"
+
+#include <gtest/gtest.h>
+
+#include "unittests/inout_pair.h"
+
+template<class T>
+void serializeTest(const T& toBeSerialized) {
+	LIZARDFS_DEFINE_INOUT_PAIR(T, toBeTested, toBeSerialized, T());
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(serialize(buffer, toBeTestedIn));
+	ASSERT_NO_THROW(deserialize(buffer, toBeTestedOut));
+
+	LIZARDFS_VERIFY_INOUT_PAIR(toBeTested);
+}
+
+TEST(SerializationTest, SerializeString) {
+	serializeTest<std::string>("jajeczniczka ze szczypiorkiem");
+}
+
+TEST(SerializationTest, SerializeUint32Vector) {
+	serializeTest<std::vector<uint32_t>>(std::vector<uint32_t>{1, 2, 3, 4});
+}
+
+TEST(SerializationTest, SerializeStringVector) {
+	serializeTest<std::vector<std::string>>(
+			std::vector<std::string>{"jajeczniczka", "ze", "szczypiorkiem"});
+}
+
+TEST(SerializationTest, DeserializeStringNonEmptyVariable) {
+	LIZARDFS_DEFINE_INOUT_PAIR(std::string, stringVariable, "good!", "BAD!");
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(serialize(buffer, stringVariableIn));
+	ASSERT_ANY_THROW(deserialize(buffer, stringVariableOut));
+}

--- a/src/unittests/inout_pair.h
+++ b/src/unittests/inout_pair.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define LIZARDFS_DEFINE_INOUT_PAIR(type, name, inVal, outVal) \
+		type name##Out = outVal, name##In = inVal
+
+#define LIZARDFS_DEFINE_INOUT_VECTOR_PAIR(type, name) \
+		std::vector<type> name##Out, name##In
+
+#define LIZARDFS_VERIFY_INOUT_PAIR(name) \
+		EXPECT_EQ(name##In, name##Out)

--- a/src/unittests/packet.h
+++ b/src/unittests/packet.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include "common/packet.h"
+
+inline void removeHeaderInPlace(std::vector<uint8_t>& packet) {
+	sassert(packet.size() >= PacketHeader::kSize);
+	packet.erase(packet.begin(), packet.begin() + PacketHeader::kSize);
+}
+
+inline void verifyHeader(const std::vector<uint8_t>& messageWithHeader,
+		PacketHeader::Type expectedType) {
+	PacketHeader header;
+	ASSERT_NO_THROW(deserializePacketHeader(messageWithHeader, header));
+	EXPECT_EQ(expectedType, header.type);
+	EXPECT_EQ(messageWithHeader.size() - PacketHeader::kSize, header.length);
+}
+
+inline void verifyHeaderInPrefix(const std::vector<uint8_t>& messagePrefixWithHeader,
+		PacketHeader::Type type, uint32_t extraDataSize) {
+	PacketHeader header;
+	ASSERT_NO_THROW(deserializePacketHeader(messagePrefixWithHeader, header));
+	EXPECT_EQ(type, header.type);
+	EXPECT_EQ(messagePrefixWithHeader.size() + extraDataSize - PacketHeader::kSize, header.length);
+}
+
+inline void verifyVersion(const std::vector<uint8_t>& messageWithoutHeader,
+		PacketVersion expectedVersion) {
+	PacketVersion version = !expectedVersion;
+	ASSERT_NO_THROW(deserializePacketVersionNoHeader(messageWithoutHeader, version));
+	EXPECT_EQ(expectedVersion, version);
+}


### PR DESCRIPTION
This patch adds LIZ_<MATOCL|CLTOMA>_IOLIMIT\* messages that will be used
in the global IO limiting mechanism. It also adds some tools that were
needed to implement these messages, concerning serialization and unit
testing.
