### PR TITLE
common: Add macro for generating serializable classes

### DIFF
--- a/src/common/serializable_class.h
+++ b/src/common/serializable_class.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cinttypes>
+
+#include "common/serialization.h"
+#include "common/serializable_class_generated.h"
+
+// A macro that helps to compute the number of parameters passed to a variadic macro:
+#define COUNT_ARGS(...) COUNT_ARGS_(, ##__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, \
+        10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define COUNT_ARGS_(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, \
+        a17, a18, a19, a20, count, ...) count
+
+// Macros used to concatenate two macro names:
+#define PASTE(a,b) a ## b
+#define PASTE_B(a,b) PASTE(a,b)
+
+#define APPLY(M, ...) M(__VA_ARGS__)
+
+// A macro that calls 'Macro' for every variadic parameter and joins results with a separator
+// Implemented with use of auto-generated APPLY1_<N>
+#define APPLY1(Macro, Sep, ...) APPLY(PASTE_B(APPLY1_, COUNT_ARGS(__VA_ARGS__)), Macro, Sep,__VA_ARGS__)
+
+// A macro that calls 'Macro' for every pair of 2 consequitive variadic parameters
+// and joins results with a separator. Implemented with use of auto-generated APPLY2_<N>
+#define APPLY2(Macro, Sep, ...) APPLY(PASTE_B(APPLY2_, COUNT_ARGS(__VA_ARGS__)), Macro, Sep, __VA_ARGS__)
+
+// A macro that converts a list [T1, t1, T2, t2, ...] into [t1, t2, ...]
+#define VARS_COMMAS(...) APPLY(PASTE_B(VARS_COMMAS_, COUNT_ARGS(__VA_ARGS__)), __VA_ARGS__)
+
+// Aliases that allow to use other macro as a call parameter:
+#define APPLY1_B(...) APPLY1(__VA_ARGS__)
+#define APPLY2_B(...) APPLY2(__VA_ARGS__)
+
+// Some simple macros usefull when defining a class:
+#define PARAMETER(t) t ## _
+#define DECLARE(T, t) T PARAMETER(t)
+#define CONST_REF(T, t) const T& t
+#define REFERENCE(T, t) T& t
+#define INITIALIZE(t) PARAMETER(t) (t)
+
+// A workaround to pass a semicolon and a comma as a [semi-]recursive macro parameter:
+#define MAKE_SEMICOLON() ;
+#define MAKE_COMMA() ,
+
+// Class variables declaration:
+#define DECLARE_VARIABLES(ClassName, ...) \
+	APPLY2(DECLARE, MAKE_SEMICOLON, __VA_ARGS__);
+
+// Tuple-like constructor:
+#define TUPLE_LIKE_CONSTRUCTOR(ClassName, ...) \
+	ClassName(APPLY2(CONST_REF, MAKE_COMMA, __VA_ARGS__)) \
+		: APPLY1_B(INITIALIZE, MAKE_COMMA, VARS_COMMAS(__VA_ARGS__)) { \
+	};
+
+// Methods used for serialization:
+#define SERIALIZE_METHODS(ClassName, ...) \
+	uint32_t serializedSize() const { \
+		return ::serializedSize( \
+			APPLY1_B(PARAMETER, MAKE_COMMA, VARS_COMMAS(__VA_ARGS__))); \
+	} \
+	void serialize(uint8_t** destination) const { \
+		return ::serialize(destination, \
+			APPLY1_B(PARAMETER, MAKE_COMMA, VARS_COMMAS(__VA_ARGS__))); \
+	} \
+	void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer) { \
+		return ::deserialize(source, bytesLeftInBuffer, \
+			APPLY1_B(PARAMETER, MAKE_COMMA, VARS_COMMAS(__VA_ARGS__))); \
+	}
+
+// Set of macros used to generate a serializable class:
+
+// A header is a class name, potentially followed by a list of ancestors, like 'Der : public Base'
+#define SERIALIZABLE_CLASS_BEGIN(ClassHeader) \
+struct ClassHeader {
+
+// A name is a repeated class name used in SERIALIZABLE_CLASS_BEGIN parameter
+#define SERIALIZABLE_CLASS_BODY(ClassName, ...) \
+	TUPLE_LIKE_CONSTRUCTOR(ClassName, __VA_ARGS__) \
+	DECLARE_VARIABLES(ClassName, __VA_ARGS__) \
+	SERIALIZE_METHODS(ClassName, __VA_ARGS__)
+
+#define SERIALIZABLE_CLASS_END }

--- a/src/common/serializable_class_generate.sh
+++ b/src/common/serializable_class_generate.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <max number of parameters to be supported>"
+    exit 1
+else
+    MAX=$1
+fi
+
+
+cat << END
+#pragma once
+
+// DO NOT MODIFY THIS FILE BY HAND!
+//
+// This file was automatically generated with $(basename $0). If you want macros below to
+// support more then $MAX parameters, generate this file once again.
+
+END
+
+for i in $(seq 1 $MAX); do
+    line="#define APPLY1_$i(Macro, Sep"
+    for j in $(seq $i); do
+        line+=", t$j"
+    done
+    line+=") Macro(t1)"
+    if [ $i -gt 1 ]; then
+        line+=" Sep() APPLY1_$((i-1))(Macro, Sep"
+        for j in $(seq 2 $i); do
+            line+=", t$j"
+        done
+        line+=")"
+    fi
+    echo $line
+done
+echo
+for i in $(seq 1 $MAX); do
+    line="#define APPLY2_$((2*i))(Macro, Sep"
+    for j in $(seq $i); do
+        line+=", T$j, t$j"
+    done
+    line+=") Macro(T1, t1)"
+    if [ $i -gt 1 ]; then
+        line+=" Sep() APPLY2_$((2*i-2))(Macro, Sep"
+        for j in $(seq 2 $i); do
+            line+=", T$j, t$j"
+        done
+        line+=")"
+    fi
+    echo $line
+done
+echo
+for i in $(seq 1 $MAX); do
+    line="#define VARS_COMMAS_$((2*i))(T1, t1";
+    for j in $(seq 2 $i); do
+        line+=", T$j, t$j";
+    done;
+    line+=") t1"
+    for j in $(seq 2 $i); do
+        line+=", t$j";
+    done;
+    echo $line;
+done
+echo
+echo "// File generated correctly."

--- a/src/common/serializable_class_generated.h
+++ b/src/common/serializable_class_generated.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// DO NOT MODIFY THIS FILE BY HAND!
+//
+// This file was automatically generated with serializable_class_generate.sh. If you want macros below to
+// support more then 15 parameters, generate this file once again.
+
+#define APPLY1_1(Macro, Sep, t1) Macro(t1)
+#define APPLY1_2(Macro, Sep, t1, t2) Macro(t1) Sep() APPLY1_1(Macro, Sep, t2)
+#define APPLY1_3(Macro, Sep, t1, t2, t3) Macro(t1) Sep() APPLY1_2(Macro, Sep, t2, t3)
+#define APPLY1_4(Macro, Sep, t1, t2, t3, t4) Macro(t1) Sep() APPLY1_3(Macro, Sep, t2, t3, t4)
+#define APPLY1_5(Macro, Sep, t1, t2, t3, t4, t5) Macro(t1) Sep() APPLY1_4(Macro, Sep, t2, t3, t4, t5)
+#define APPLY1_6(Macro, Sep, t1, t2, t3, t4, t5, t6) Macro(t1) Sep() APPLY1_5(Macro, Sep, t2, t3, t4, t5, t6)
+#define APPLY1_7(Macro, Sep, t1, t2, t3, t4, t5, t6, t7) Macro(t1) Sep() APPLY1_6(Macro, Sep, t2, t3, t4, t5, t6, t7)
+#define APPLY1_8(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8) Macro(t1) Sep() APPLY1_7(Macro, Sep, t2, t3, t4, t5, t6, t7, t8)
+#define APPLY1_9(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9) Macro(t1) Sep() APPLY1_8(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9)
+#define APPLY1_10(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) Macro(t1) Sep() APPLY1_9(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+#define APPLY1_11(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) Macro(t1) Sep() APPLY1_10(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+#define APPLY1_12(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) Macro(t1) Sep() APPLY1_11(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)
+#define APPLY1_13(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) Macro(t1) Sep() APPLY1_12(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
+#define APPLY1_14(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) Macro(t1) Sep() APPLY1_13(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+#define APPLY1_15(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) Macro(t1) Sep() APPLY1_14(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
+
+#define APPLY2_2(Macro, Sep, T1, t1) Macro(T1, t1)
+#define APPLY2_4(Macro, Sep, T1, t1, T2, t2) Macro(T1, t1) Sep() APPLY2_2(Macro, Sep, T2, t2)
+#define APPLY2_6(Macro, Sep, T1, t1, T2, t2, T3, t3) Macro(T1, t1) Sep() APPLY2_4(Macro, Sep, T2, t2, T3, t3)
+#define APPLY2_8(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4) Macro(T1, t1) Sep() APPLY2_6(Macro, Sep, T2, t2, T3, t3, T4, t4)
+#define APPLY2_10(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5) Macro(T1, t1) Sep() APPLY2_8(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5)
+#define APPLY2_12(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6) Macro(T1, t1) Sep() APPLY2_10(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6)
+#define APPLY2_14(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7) Macro(T1, t1) Sep() APPLY2_12(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7)
+#define APPLY2_16(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8) Macro(T1, t1) Sep() APPLY2_14(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8)
+#define APPLY2_18(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9) Macro(T1, t1) Sep() APPLY2_16(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9)
+#define APPLY2_20(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10) Macro(T1, t1) Sep() APPLY2_18(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10)
+#define APPLY2_22(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11) Macro(T1, t1) Sep() APPLY2_20(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11)
+#define APPLY2_24(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12) Macro(T1, t1) Sep() APPLY2_22(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12)
+#define APPLY2_26(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13) Macro(T1, t1) Sep() APPLY2_24(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13)
+#define APPLY2_28(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14) Macro(T1, t1) Sep() APPLY2_26(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14)
+#define APPLY2_30(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15) Macro(T1, t1) Sep() APPLY2_28(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15)
+
+#define VARS_COMMAS_2(T1, t1) t1
+#define VARS_COMMAS_4(T1, t1, T2, t2) t1, t2
+#define VARS_COMMAS_6(T1, t1, T2, t2, T3, t3) t1, t2, t3
+#define VARS_COMMAS_8(T1, t1, T2, t2, T3, t3, T4, t4) t1, t2, t3, t4
+#define VARS_COMMAS_10(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5) t1, t2, t3, t4, t5
+#define VARS_COMMAS_12(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6) t1, t2, t3, t4, t5, t6
+#define VARS_COMMAS_14(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7) t1, t2, t3, t4, t5, t6, t7
+#define VARS_COMMAS_16(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8) t1, t2, t3, t4, t5, t6, t7, t8
+#define VARS_COMMAS_18(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9) t1, t2, t3, t4, t5, t6, t7, t8, t9
+#define VARS_COMMAS_20(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10
+#define VARS_COMMAS_22(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11
+#define VARS_COMMAS_24(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12
+#define VARS_COMMAS_26(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13
+#define VARS_COMMAS_28(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14
+#define VARS_COMMAS_30(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15
+
+// File generated correctly.

--- a/src/common/serializable_class_unittest.cc
+++ b/src/common/serializable_class_unittest.cc
@@ -1,0 +1,59 @@
+#include "common/serializable_class.h"
+
+#include <gtest/gtest.h>
+#include <tuple>
+
+#include "unittests/inout_pair.h"
+
+TEST(SerializableClassTests, SimpleClass) {
+	class Base {};
+	SERIALIZABLE_CLASS_BEGIN(SomeClass : public Base)
+	SERIALIZABLE_CLASS_BODY(
+		SomeClass,
+		int   , fieldA,
+		short , fieldB,
+		long  , fieldC
+	)
+		SomeClass() = default;
+		void myMethod() {
+			fieldA_ = 5;
+		};
+	SERIALIZABLE_CLASS_END;
+
+	SomeClass a;
+	(void) a.fieldA_;
+	(void) a.fieldB_;
+	(void) a.fieldC_;
+	a.myMethod();
+}
+
+TEST(SerializableClassTests, Serialize) {
+	SERIALIZABLE_CLASS_BEGIN(Class)
+	SERIALIZABLE_CLASS_BODY(
+		Class,
+		int   , A,
+		short , B,
+		long  , C,
+		std::string             , D,
+		std::vector<std::string>, E
+	)
+		Class() = default;
+		bool operator==(const Class& o) const {
+			return std::make_tuple(A_, B_, C_) == std::make_tuple(o.A_, o.B_, o.C_);
+		}
+		bool operator!=(const Class& o) const {
+			return !(*this == o);
+		}
+	SERIALIZABLE_CLASS_END;
+
+	std::vector<std::string> tmpVector {"kogo", "ma", "ala", "?"};
+	Class tmpC {1, 20, 300, "ala ma kota", tmpVector};
+
+	LIZARDFS_DEFINE_INOUT_PAIR(Class, c, tmpC, Class());
+	ASSERT_NE(cIn, cOut);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(serialize(buffer, cIn));
+	ASSERT_NO_THROW(deserialize(buffer, cOut));
+	LIZARDFS_VERIFY_INOUT_PAIR(c);
+}

--- a/src/common/serialization.h
+++ b/src/common/serialization.h
@@ -37,6 +37,22 @@ inline uint32_t serializedSize(const uint64_t&) {
 	return 8;
 }
 
+inline uint32_t serializedSize(const int8_t&) {
+	return 1;
+}
+
+inline uint32_t serializedSize(const int16_t&) {
+	return 2;
+}
+
+inline uint32_t serializedSize(const int32_t&) {
+	return 4;
+}
+
+inline uint32_t serializedSize(const int64_t&) {
+	return 8;
+}
+
 inline uint32_t serializedSize(const char& c) {
 	return serializedSize(reinterpret_cast<const uint8_t&>(c));
 }
@@ -70,6 +86,11 @@ inline uint32_t serializedSize(const std::vector<T>& vector) {
 	return vector.size() * serializedSize(T());
 }
 
+template<class T>
+inline uint32_t serializedSize(const T& t) {
+	return t.serializedSize();
+}
+
 template<class T, class ... Args>
 inline uint32_t serializedSize(const T& t, const Args& ... args) {
 	return serializedSize(t) + serializedSize(args...);
@@ -82,23 +103,35 @@ inline void serialize(uint8_t** destination, const bool& value) {
 	put8bit(destination, static_cast<uint8_t>(value ? 1 : 0));
 }
 
-// serialize uint8_t
 inline void serialize(uint8_t** destination, const uint8_t& value) {
 	put8bit(destination, value);
 }
 
-// serialize uint16_t
 inline void serialize(uint8_t** destination, const uint16_t& value) {
 	put16bit(destination, value);
 }
 
-// serialize uint32_t
 inline void serialize(uint8_t** destination, const uint32_t& value) {
 	put32bit(destination, value);
 }
 
-// serialize uint64_t
 inline void serialize(uint8_t** destination, const uint64_t& value) {
+	put64bit(destination, value);
+}
+
+inline void serialize(uint8_t** destination, const int8_t& value) {
+	put8bit(destination, value);
+}
+
+inline void serialize(uint8_t** destination, const int16_t& value) {
+	put16bit(destination, value);
+}
+
+inline void serialize(uint8_t** destination, const int32_t& value) {
+	put32bit(destination, value);
+}
+
+inline void serialize(uint8_t** destination, const int64_t& value) {
 	put64bit(destination, value);
 }
 
@@ -143,6 +176,11 @@ inline void serialize(uint8_t** destination, const std::vector<T>& vector) {
 	}
 }
 
+template<class T>
+inline void serialize(uint8_t** destination, const T& t) {
+	return t.serialize(destination);
+}
+
 template<class T, class... Args>
 inline void serialize(uint8_t** destination, const T& t, const Args&... args) {
 	serialize(destination, t);
@@ -160,7 +198,6 @@ inline void verifySize(const T& value, uint32_t bytesLeft) {
 
 // deserialize functions for simple types
 
-// deserialize bool
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, bool& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 1;
@@ -171,29 +208,49 @@ inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, boo
 	value = static_cast<bool>(integerValue);
 }
 
-// deserialize uint8_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint8_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 1;
 	value = get8bit(source);
 }
 
-// deserialize uint16_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint16_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 2;
 	value = get16bit(source);
 }
 
-// deserialize uint32_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint32_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 4;
 	value = get32bit(source);
 }
 
-// deserialize uint64_t
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, uint64_t& value) {
+	verifySize(value, bytesLeftInBuffer);
+	bytesLeftInBuffer -= 8;
+	value = get64bit(source);
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, int8_t& value) {
+	verifySize(value, bytesLeftInBuffer);
+	bytesLeftInBuffer -= 1;
+	value = get8bit(source);
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, int16_t& value) {
+	verifySize(value, bytesLeftInBuffer);
+	bytesLeftInBuffer -= 2;
+	value = get16bit(source);
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, int32_t& value) {
+	verifySize(value, bytesLeftInBuffer);
+	bytesLeftInBuffer -= 4;
+	value = get32bit(source);
+}
+
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, int64_t& value) {
 	verifySize(value, bytesLeftInBuffer);
 	bytesLeftInBuffer -= 8;
 	value = get64bit(source);
@@ -265,6 +322,11 @@ inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
 	for (size_t i = 0; i < vecSize; ++i) {
 		deserialize(source, bytesLeftInBuffer, vector[i]);
 	}
+}
+
+template<class T>
+inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, T& t) {
+	return t.deserialize(source, bytesLeftInBuffer);
 }
 
 template<class T, class... Args>


### PR DESCRIPTION
Add a macro that defines a class, that has automatically generated
methods for serialization. Due to the genericness of this
implementation, there is no need to implement a unit test that
checks if serialization works fine for objects created with use
of this macro.

The macro should be used like this:

include "common/serializable_class.h"

SERIALIZABLE_CLASS_BEGIN(MyClassName : public SomeBase)
SERIALIZABLE_CLASS_BODY(
    MyClassName,
    int   , fieldA,
    double, fieldB,
    long  , fieldC
)
    // Macro doesn't close class definition bracket, so we can provide
    // any additional code we want:
    MyClassName() = default; // Like a constructor
    void myMethod() {
        fieldA_ = 5; // We can also use class fields using underscore
    }
SERIALIZABLE_CLASS_END

int main() {
    MyClassName a = MyClassName(0, 1.0, 2l); // A tuple-like
                            // constructor is also generated
    std::vector<uint8_t> buffer;
    serialize(buffer, a);
}

Change-Id: I3bd3f1e1ed2111f89aa9561c0d1571d5e424b23a
