### PR TITLE
common: Reorganize code serializing vectors

### DIFF
--- a/src/common/moosefs_vector.h
+++ b/src/common/moosefs_vector.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "common/serialization.h"
+
+// This class behaves just as std::vector, with the exception that it is serialized
+// differently. MooseFS does not send array length when serializing it, LizardFS does.
+template <class T>
+class MooseFSVector : public std::vector<T> {
+public:
+	static_assert(IsConstSerializedSize<T>::value,
+			"Incorrect template parameter for MooseFSVector");
+
+	// Gcc 4.6 which we support don't support inherited constructors,
+	// so a workaround was needed:
+	template<typename... Args>
+	MooseFSVector(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {
+	}
+
+	uint32_t serializedSize() const {
+		return this->size() * ::serializedSize(T());
+	}
+	void serialize(uint8_t** destination) const {
+		for (const T& t : *this) {
+			::serialize(destination, t);
+		}
+	}
+	void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer) {
+		size_t sizeOfElement = ::serializedSize(T());
+		sassert(this->size() == 0);
+		sassert(sizeOfElement > 0);
+		if (bytesLeftInBuffer % sizeOfElement != 0) {
+			throw IncorrectDeserializationException(
+					"vector: buffer size not divisible by element size");
+		}
+		size_t vecSize = bytesLeftInBuffer / sizeOfElement;
+		this->resize(vecSize);
+		for (size_t i = 0; i < vecSize; ++i) {
+			::deserialize(source, bytesLeftInBuffer, (*this)[i]);
+		}
+	}
+};

--- a/src/common/moosefs_vector_unittest.cc
+++ b/src/common/moosefs_vector_unittest.cc
@@ -1,0 +1,56 @@
+#include "common/moosefs_vector.h"
+
+#include <gtest/gtest.h>
+
+#include "unittests/inout_pair.h"
+
+TEST(MooseFSVectorTest, GeneralBehaviour) {
+	MooseFSVector<int>    vec1_A;
+	std::vector<int>      vec1_B;
+	EXPECT_EQ(vec1_A, vec1_B);
+
+	MooseFSVector<double> vec2_A(5, 1.0);
+	std::vector<double>   vec2_B(5, 1.0);
+	EXPECT_EQ(vec2_A, vec2_B);
+
+	MooseFSVector<double> vec3_A(vec2_B);
+	std::vector<double>   vec3_B(vec2_A);
+	EXPECT_EQ(vec2_B, vec3_A);
+	EXPECT_EQ(vec2_A, vec3_B);
+
+	vec1_A.push_back(5);
+	EXPECT_NE(vec1_A, vec1_B);
+	vec2_A[0] = 2.0;
+	EXPECT_NE(vec2_A, vec2_B);
+}
+
+TEST(MooseFSVectorTest, Serialization) {
+	typedef std::vector<uint16_t>   OrdinaryVec;
+	typedef MooseFSVector<uint16_t> MooseFsVec;
+
+	OrdinaryVec o1 {1, 20, 300, 400};
+	OrdinaryVec o2 (o1);
+	MooseFsVec  m1 (o1);
+	MooseFsVec  m2 (o1);
+
+	std::vector<uint8_t> o_buffers[2];
+	serialize(o_buffers[0], o1);
+	serialize(o_buffers[1], o2);
+
+	std::vector<uint8_t> m_buffers[2];
+	serialize(m_buffers[0], m1);
+	serialize(m_buffers[1], m2);
+
+	// Check if MooseFSVector is serialized differently then std::vector:
+	ASSERT_NE(o_buffers[0], m_buffers[0]);
+
+	// Check if MooseFSVectors is always serialized the same way:
+	ASSERT_EQ(m_buffers[0], m_buffers[1]);
+	// Same about std::vector:
+	ASSERT_EQ(o_buffers[0], o_buffers[1]);
+
+	MooseFsVec m1_deserialized;
+	ASSERT_NE(m1, m1_deserialized);
+	deserialize(m_buffers[0], m1_deserialized);
+	ASSERT_EQ(m1, m1_deserialized);
+}

--- a/src/common/serialization.h
+++ b/src/common/serialization.h
@@ -15,6 +15,77 @@ public:
 			Exception("Deserialization error: " + message) {}
 };
 
+template<class T>
+struct IsConstSerializedSize {
+	static constexpr bool value = false;
+};
+
+template<>
+struct IsConstSerializedSize<uint8_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<uint16_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<uint32_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<uint64_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<int8_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<int16_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<int32_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<int64_t> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<char> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<float> {
+	static constexpr bool value = true;
+};
+
+template<>
+struct IsConstSerializedSize<double> {
+	static constexpr bool value = true;
+};
+
+template<class T, int N>
+struct IsConstSerializedSize<T[N]> {
+	static constexpr bool value = IsConstSerializedSize<T>::value;
+};
+
+template<class T1, class T2>
+struct IsConstSerializedSize<std::pair<T1, T2>> {
+	static constexpr bool value = IsConstSerializedSize<T1>::value
+			&& IsConstSerializedSize<T2>::value;
+};
+
 // serializedSize
 
 inline uint32_t serializedSize(const bool&) {
@@ -72,18 +143,14 @@ inline uint32_t serializedSize(const std::string& value) {
 			+ serializedSize(std::string::value_type()) * value.size();
 }
 
-inline uint32_t serializedSize(const std::vector<std::string>& vector) {
-	uint32_t ret = 0;
-	ret += serializedSize(uint32_t(vector.size()));
-	for (const auto& str : vector) {
-		ret += serializedSize(str);
-	}
-	return ret;
-}
-
 template<class T>
 inline uint32_t serializedSize(const std::vector<T>& vector) {
-	return vector.size() * serializedSize(T());
+	uint32_t ret = 0;
+	ret += serializedSize(uint32_t(vector.size()));
+	for (const auto& t : vector) {
+		ret += serializedSize(t);
+	}
+	return ret;
 }
 
 template<class T>
@@ -161,16 +228,9 @@ inline void serialize(uint8_t** destination, const std::string& value) {
 	}
 }
 
-inline void serialize(uint8_t** destination, const std::vector<std::string>& vector) {
-	serialize(destination, uint32_t(vector.size()));
-	for (const auto& str : vector) {
-		serialize(destination, str);
-	}
-}
-
-// serialize a vector
 template<class T>
 inline void serialize(uint8_t** destination, const std::vector<T>& vector) {
+	serialize(destination, uint32_t(vector.size()));
 	for (const T& t : vector) {
 		serialize(destination, t);
 	}
@@ -295,32 +355,15 @@ inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, std
 	}
 }
 
+template<class T>
 inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
-		std::vector<std::string>& vec) {
+		std::vector<T>& vec) {
 	sassert(vec.size() == 0);
 	uint32_t size;
 	deserialize(source, bytesLeftInBuffer, size);
 	vec.resize(size);
 	for (unsigned i = 0; i < size; ++i) {
 		deserialize(source, bytesLeftInBuffer, vec[i]);
-	}
-}
-
-// deserialize a vector
-template<class T>
-inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer,
-		std::vector<T>& vector) {
-	size_t sizeOfElement = serializedSize(T());
-	sassert(vector.size() == 0);
-	sassert(sizeOfElement > 0);
-	if (bytesLeftInBuffer % sizeOfElement != 0) {
-		throw IncorrectDeserializationException(
-				"vector: buffer size not divisible by element size");
-	}
-	size_t vecSize = bytesLeftInBuffer / sizeOfElement;
-	vector.resize(vecSize);
-	for (size_t i = 0; i < vecSize; ++i) {
-		deserialize(source, bytesLeftInBuffer, vector[i]);
 	}
 }
 
@@ -340,9 +383,8 @@ inline void deserialize(const uint8_t** source, uint32_t& bytesLeftInBuffer, T& 
  */
 template <class T>
 inline void deserializeAndIgnore(const uint8_t** source, uint32_t& bytesLeftInBuffer) {
-	verifySize(T(), bytesLeftInBuffer);
-	*source += serializedSize(T());
-	bytesLeftInBuffer -= serializedSize(T());
+	T dummy;
+	deserialize(source, bytesLeftInBuffer, dummy);
 }
 
 /*


### PR DESCRIPTION
LizardFS does send vector length when serializing it, MooseFS does
not. This patch provides code needed to do both types of serialization.
