### PR TITLE
tests: Add stack trace

### DIFF
--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -1,8 +1,8 @@
 # Assertion types:
 # * expect_some_condition -- adds error to the test results, but continues the test
 # * assert_some_condition -- adds error to the test results and immediately stops the test
-# * assertlocal_some_condition -- adds error to the results and exits current subshell 
- 
+# * assertlocal_some_condition -- adds error to the results and exits current subshell
+
 # (assert|assertlocal|expect)_program_installed <program>
 assert_template_program_installed_() {
 	local program=$1
@@ -72,6 +72,9 @@ create_error_message_() {
 	fi
 	echo "$*"
 	echo "Location: $(basename "$ASSERT_FILE"):$ASSERT_LINE"
+	echo "Backtrace:"
+	# remove top 3 function calls from stack trace: create_error_message_, do_*_failed_, assert_template_*
+	print_stack 3
 }
 
 do_assert_failed_() {

--- a/tests/tools/stack_trace.sh
+++ b/tests/tools/stack_trace.sh
@@ -1,0 +1,39 @@
+function get_stack () {
+	# bash throws an error "Unbound variable" when dealing with empty arrays
+	set +u
+	STACK=""
+	# to avoid noise we start with $1 + 1 to skip get_stack caller
+	# (and other functions, if the user whishes to)
+	local skip
+	skip=$((${1} + 1))
+	local i
+	local stack_size=${#FUNCNAME[@]}
+	local argv_beg=0 # where arguments for current function begin
+	for (( i = 0; i < stack_size; ++i )); do
+		local func=${FUNCNAME[$i]}
+		local line=${BASH_LINENO[$i]}
+		local src=${BASH_SOURCE[$((i + 1))]}
+		local arguments_count=${BASH_ARGC[$i]:-0}
+		local args=()
+		local j
+		for (( j = argv_beg + arguments_count - 1; j >= argv_beg; --j )); do
+			args+=("'${BASH_ARGV[$j]}'")
+		done
+		argv_beg=$((argv_beg + arguments_count))
+		if (( i >= skip && line > 0 )); then
+			# join arguments with commas
+			local joined_args=$(IFS=, ; echo "${args[*]}")
+			STACK+="$(basename "$src"):$line $func(${joined_args})"$'\n'
+		fi
+	done
+	set -u
+}
+
+function print_stack () {
+	local skip
+	skip=$((${1:-0} + 1))
+	get_stack $skip # remove get_stack_echo from stack trace
+	# Print red message to the console
+	echo -n "$STACK"
+	unset STACK
+}

--- a/tests/tools/test_main.sh
+++ b/tests/tools/test_main.sh
@@ -2,7 +2,7 @@ set -eu
 
 # Enable alias expansion and clear inherited aliases.
 unalias -a
-shopt -s expand_aliases
+shopt -s expand_aliases extdebug
 
 command_prefix=
 for i in mfsmaster mfschunkserver mfsmount mfsmetarestore mfsmetalogger; do
@@ -10,6 +10,7 @@ for i in mfsmaster mfschunkserver mfsmount mfsmetarestore mfsmetalogger; do
 done
 
 . tools/config.sh # This has to be the first one
+. tools/stack_trace.sh
 . tools/assert.sh
 . tools/lizardfs.sh
 . tools/network.sh


### PR DESCRIPTION
With assert inside functions it was difficult to trace errors since
there was no way to tell where a function was called from.
This commit adds get_stack and print_stack functions which display
the call stack with the file and the line where the function was called
from along with the arguments.
