### PR TITLE
common: Modify serializable_class and MooseFSVector

### DIFF
--- a/src/common/moosefs_vector.h
+++ b/src/common/moosefs_vector.h
@@ -14,7 +14,11 @@ public:
 	}
 
 	uint32_t serializedSize() const {
-		return this->size() * ::serializedSize(T());
+		uint32_t ret = 0;
+		for (const auto& element : *this) {
+			ret += ::serializedSize(element);
+		}
+		return ret;
 	}
 	void serialize(uint8_t** destination) const {
 		for (const T& t : *this) {
@@ -25,14 +29,9 @@ public:
 		size_t sizeOfElement = ::serializedSize(T());
 		sassert(this->size() == 0);
 		sassert(sizeOfElement > 0);
-		if (bytesLeftInBuffer % sizeOfElement != 0) {
-			throw IncorrectDeserializationException(
-					"vector: buffer size not divisible by element size");
-		}
-		size_t vecSize = bytesLeftInBuffer / sizeOfElement;
-		this->resize(vecSize);
-		for (size_t i = 0; i < vecSize; ++i) {
-			::deserialize(source, bytesLeftInBuffer, (*this)[i]);
+		while (bytesLeftInBuffer > 0) {
+			this->push_back(T());
+			::deserialize(source, bytesLeftInBuffer, this->back());
 		}
 	}
 };

--- a/src/common/serializable_class.h
+++ b/src/common/serializable_class.h
@@ -5,12 +5,6 @@
 #include "common/serialization.h"
 #include "common/serializable_class_generated.h"
 
-// A macro that helps to compute the number of parameters passed to a variadic macro:
-#define COUNT_ARGS(...) COUNT_ARGS_(, ##__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, \
-        10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
-#define COUNT_ARGS_(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, \
-        a17, a18, a19, a20, count, ...) count
-
 // Macros used to concatenate two macro names:
 #define PASTE(a,b) a ## b
 #define PASTE_B(a,b) PASTE(a,b)

--- a/src/common/serializable_class_generate.sh
+++ b/src/common/serializable_class_generate.sh
@@ -64,4 +64,18 @@ for i in $(seq 1 $MAX); do
     echo $line;
 done
 echo
+line="#define COUNT_ARGS(...) COUNT_ARGS_(, ##__VA_ARGS__"
+for i in $(seq $((MAX * 2)) -1 0); do
+    line="${line}, $i"
+done
+line="${line})"
+echo $line
+echo
+line="#define COUNT_ARGS_("
+for i in $(seq 0 $((MAX * 2 ))); do
+    line="${line}a$i, "
+done
+line="${line}count, ...) count"
+echo $line
+echo
 echo "// File generated correctly."

--- a/src/common/serializable_class_generated.h
+++ b/src/common/serializable_class_generated.h
@@ -3,7 +3,7 @@
 // DO NOT MODIFY THIS FILE BY HAND!
 //
 // This file was automatically generated with serializable_class_generate.sh. If you want macros below to
-// support more then 15 parameters, generate this file once again.
+// support more then 20 parameters, generate this file once again.
 
 #define APPLY1_1(Macro, Sep, t1) Macro(t1)
 #define APPLY1_2(Macro, Sep, t1, t2) Macro(t1) Sep() APPLY1_1(Macro, Sep, t2)
@@ -20,6 +20,11 @@
 #define APPLY1_13(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) Macro(t1) Sep() APPLY1_12(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
 #define APPLY1_14(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) Macro(t1) Sep() APPLY1_13(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
 #define APPLY1_15(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) Macro(t1) Sep() APPLY1_14(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
+#define APPLY1_16(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) Macro(t1) Sep() APPLY1_15(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)
+#define APPLY1_17(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) Macro(t1) Sep() APPLY1_16(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)
+#define APPLY1_18(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18) Macro(t1) Sep() APPLY1_17(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)
+#define APPLY1_19(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19) Macro(t1) Sep() APPLY1_18(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)
+#define APPLY1_20(Macro, Sep, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20) Macro(t1) Sep() APPLY1_19(Macro, Sep, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)
 
 #define APPLY2_2(Macro, Sep, T1, t1) Macro(T1, t1)
 #define APPLY2_4(Macro, Sep, T1, t1, T2, t2) Macro(T1, t1) Sep() APPLY2_2(Macro, Sep, T2, t2)
@@ -36,6 +41,11 @@
 #define APPLY2_26(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13) Macro(T1, t1) Sep() APPLY2_24(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13)
 #define APPLY2_28(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14) Macro(T1, t1) Sep() APPLY2_26(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14)
 #define APPLY2_30(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15) Macro(T1, t1) Sep() APPLY2_28(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15)
+#define APPLY2_32(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16) Macro(T1, t1) Sep() APPLY2_30(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16)
+#define APPLY2_34(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17) Macro(T1, t1) Sep() APPLY2_32(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17)
+#define APPLY2_36(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18) Macro(T1, t1) Sep() APPLY2_34(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18)
+#define APPLY2_38(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19) Macro(T1, t1) Sep() APPLY2_36(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19)
+#define APPLY2_40(Macro, Sep, T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19, T20, t20) Macro(T1, t1) Sep() APPLY2_38(Macro, Sep, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19, T20, t20)
 
 #define VARS_COMMAS_2(T1, t1) t1
 #define VARS_COMMAS_4(T1, t1, T2, t2) t1, t2
@@ -52,5 +62,14 @@
 #define VARS_COMMAS_26(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13
 #define VARS_COMMAS_28(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14
 #define VARS_COMMAS_30(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15
+#define VARS_COMMAS_32(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16
+#define VARS_COMMAS_34(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17
+#define VARS_COMMAS_36(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18
+#define VARS_COMMAS_38(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19
+#define VARS_COMMAS_40(T1, t1, T2, t2, T3, t3, T4, t4, T5, t5, T6, t6, T7, t7, T8, t8, T9, t9, T10, t10, T11, t11, T12, t12, T13, t13, T14, t14, T15, t15, T16, t16, T17, t17, T18, t18, T19, t19, T20, t20) t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20
+
+#define COUNT_ARGS(...) COUNT_ARGS_(, ##__VA_ARGS__, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+#define COUNT_ARGS_(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, count, ...) count
 
 // File generated correctly.


### PR DESCRIPTION
- Make COUNT_ARGS and COUNT_ARGS_ macros automatically generated.
- Make MooseFSVectar be able to serialize vectors of types
  which instances can have different sizes.
