### PR TITLE
cmake: Disable in-source builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 ######################
 /external/crcutil-1.0
 /external/gtest-1.7.0
-gtest-1.7.0.zip
 
 # Vim files #
 #############
@@ -32,64 +31,3 @@ compile_commands.json
 # QtCreator user profiles #
 ###########################
 *.user
-
-# Files from a bare "cmake ." invocation #
-##########################################
-CMakeCache.txt
-*CMakeFiles/
-*cmake_install.cmake
-CPackConfig.cmake
-CPackSourceConfig.cmake
-Makefile
-config.h
-crcutil-1.0.tar.gz
-doc/Makefile
-external/Makefile
-src/cgi/Makefile
-src/cgi/chart.cgi
-src/cgi/mfs.cgi
-src/cgi/mfscgiserv.py
-src/chunkserver/Makefile
-src/common/Makefile
-src/data/Makefile
-src/data/mfschunkserver.cfg
-src/data/mfsmaster.cfg
-src/data/mfsmetalogger.cfg
-src/data/postinst
-src/master/Makefile
-src/metadump/Makefile
-src/metalogger/Makefile
-src/metarestore/Makefile
-src/mount/Makefile
-src/tools/Makefile
-
-# Files after running "make" #
-##############################
-external/libcrcutil.a
-src/chunkserver/libchunkserver.a
-src/chunkserver/mfschunkserver
-src/common/libmfscommon.a
-src/master/libmaster.a
-src/master/mfsmaster
-src/metadump/mfsmetadump
-src/metalogger/libmetalogger.a
-src/metalogger/mfsmetalogger
-src/metarestore/libmetarestore.a
-src/metarestore/mfsmetarestore
-src/mount/libmount.a
-src/mount/mfsmount
-src/tools/mfsappendchunks
-src/tools/mfscheckfile
-src/tools/mfsdeleattr
-src/tools/mfsdirinfo
-src/tools/mfsfileinfo
-src/tools/mfsfilerepair
-src/tools/mfsgeteattr
-src/tools/mfsgetgoal
-src/tools/mfsgettrashtime
-src/tools/mfsmakesnapshot
-src/tools/mfsseteattr
-src/tools/mfssetgoal
-src/tools/mfssettrashtime
-src/tools/mfstools
-src/unittests/unittests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,21 @@ cmake_minimum_required(VERSION 2.8)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_MODULE_PATH})
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR
+    "In-source builds are disabled for this project. This is for your "
+    "safety. To build the project, please create a build tree in "
+    "a separate directory, for example:\n"
+    "     mkdir ${CMAKE_SOURCE_DIR}/build\n"
+    "     cd ${CMAKE_SOURCE_DIR}/build\n"
+    "     cmake ..\n"
+    "Before doing that you may need to clean up after this try by removing "
+    "CMakeCache.txt file and CMakeFiles/ directory.\n"
+    "If you REALLY need an in-source build, remove this check from "
+    "${CMAKE_CURRENT_LIST_FILE} and try again."
+  )
+endif()
+
 project(lizardfs)
 set(PACKAGE_VERSION_MAJOR 1)
 set(PACKAGE_VERSION_MINOR 6)


### PR DESCRIPTION
In-source build are generally discouraged, see eg:
- http://www.cmake.org/Wiki/CMake_FAQ#I_run_an_out-of-source_build_but_CMake_generates_in-source_anyway._Why.3F
- http://www.cmake.org/Wiki/CMake_FAQ#What_is_an_.22out-of-source.22_build.3F

Moreover:
- Creating an in-source build makes it impossible to create a Debian
  package using this directory, because our package building mechanism
  needs to create a temporary out-of-source build tree
- Maintaining `.gitignore` file for in-source builds is a nuisance

For these reasons this commit removes entries for in-source builds from
`.gitignore` and makes it impossible to run such a build using `cmake`.
