### PR TITLE
cgi: Fix file paths

### DIFF
--- a/src/cgi/mfs.cgi.in
+++ b/src/cgi/mfs.cgi.in
@@ -327,7 +327,7 @@ except Exception:
 	print """<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />"""
 	print """<title>LizardFS Info (%s)</title>""" % (htmlentities(mastername))
 	print """<link href="favicon.ico" rel="icon" type="image/x-icon" />"""
-	print """<link rel="stylesheet" href="/mfs.css" type="text/css" />"""
+	print """<link rel="stylesheet" href="mfs.css" type="text/css" />"""
 	print """</head>"""
 	print """<body>"""
 	print """<h1 align="center">Can't connect to MFS master (IP:%s ; PORT:%u)</h1>""" % (htmlentities(masterhost),masterport)
@@ -344,7 +344,7 @@ if masterversion==(0,0,0):
 	print """<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />"""
 	print """<title>LizardFS Info (%s)</title>""" % (htmlentities(mastername))
 	print """<link href="favicon.ico" rel="icon" type="image/x-icon" />"""
-	print """<link rel="stylesheet" href="/mfs.css" type="text/css" />"""
+	print """<link rel="stylesheet" href="mfs.css" type="text/css" />"""
 	print """</head>"""
 	print """<body>"""
 	print """<h1 align="center">Can't detect MFS master version</h1>"""
@@ -408,7 +408,7 @@ if fields.has_key("CSremove"):
 		print """<meta http-equiv="Refresh" content="0; url=%s" />""" % url
 		print """<title>LizardFS Info (%s)</title>""" % (htmlentities(mastername))
 		print """<link href="favicon.ico" rel="icon" type="image/x-icon" />"""
-		print """<link rel="stylesheet" href="/mfs.css" type="text/css" />"""
+		print """<link rel="stylesheet" href="mfs.css" type="text/css" />"""
 		print """</head>"""
 		print """<body>"""
 		print """<h1 align="center"><a href="%s">If you see this then it means that redirection didn't work, so click here</a></h1>"""
@@ -424,7 +424,7 @@ if fields.has_key("CSremove"):
 		print """<meta http-equiv="Refresh" content="5; url=%s" />""" % url
 		print """<title>LizardFS Info (%s)</title>""" % (htmlentities(mastername))
 		print """<link href="favicon.ico" rel="icon" type="image/x-icon" />"""
-		print """<link rel="stylesheet" href="/mfs.css" type="text/css" />"""
+		print """<link rel="stylesheet" href="mfs.css" type="text/css" />"""
 		print """</head>"""
 		print """<body>"""
 		print """<h3 align="center">Can't remove server (%s) from list - wait 5 seconds for refresh</h3>""" % fields.getvalue("CSremove")
@@ -490,7 +490,7 @@ print """<head>"""
 print """<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />"""
 print """<title>LizardFS Info (%s)</title>""" % (htmlentities(mastername))
 print """<link href="favicon.ico" rel="icon" type="image/x-icon" />"""
-print """<link rel="stylesheet" href="/mfs.css" type="text/css" />"""
+print """<link rel="stylesheet" href="mfs.css" type="text/css" />"""
 print """</head>"""
 print """<body>"""
 
@@ -498,7 +498,7 @@ print """<body>"""
 print """<div id="header">"""
 print """<table class="HDR" cellpadding="0" cellspacing="0" border="0" summary="Page header">"""
 print """<tr>"""
-print """<td class="LOGO"><a href="http://www.lizardfs.org"><img src="/logomini.png" alt="logo" style="border:0;width:123px;height:47px" /></a></td>"""
+print """<td class="LOGO"><a href="http://www.lizardfs.org"><img src="logomini.png" alt="logo" style="border:0;width:123px;height:47px" /></a></td>"""
 print """<td class="MENU"><table class="MENU" cellspacing="0" summary="Header menu">"""
 print """<tr>"""
 last="U"


### PR DESCRIPTION
old pull request: #167

mfs.cgi not working properly with apache virtual directory

example Apache config:

```
Alias /mfs/ "/usr/share/mfscgi/"
<Directory "/usr/share/mfscgi/">
        AllowOverride None
        Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
        Order allow,deny
        Allow from all
        AddHandler cgi-script .cgi
</Directory>
```

currently Web browser tries to access the files
http://192.168.1.10/mfs.css
http://192.168.1.10/logomini.png

instead of: 
http://192.168.1.10/mfs/mfs.css
http://192.168.1.10/mfs/logomini.png

patch fixes a bug and for me works correctly with mfscgiserv and apache.
