### PR TITLE
Add lizardfs-cluster init script to manage cluster state for HA

### DIFF
--- a/debian/lizardfs-cluster.init
+++ b/debian/lizardfs-cluster.init
@@ -1,0 +1,170 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:		lizardfs-cluster
+# Required-Start:	$network $remote_fs
+# Required-Stop:	$remote_fs
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	Check and change status of LizardFS cluster
+# Description:		lizardfs-cluster provides cluster management for LizardFS.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME=lfscluster
+DESC=lizardfs-cluster
+DEFAULT_WORKING_USER=mfs
+DEFAULT_WORKING_GROUP=mfs
+DEFAULT_DATA_PATH=/var/lib/mfs
+DEFAULT_RUN_PATH=/var/run/mfs
+DEFAULT_CFG=/etc/mfs/mfsmaster.cfg
+COMPAT_CFG=/etc/mfsmaster.cfg
+
+test -e $DAEMON || exit 0
+
+# Include lizardfs-master defaults if available
+. /lib/lsb/init-functions
+LIZARDFSMASTER_ENABLE=false
+LIZARDFSMASTER_CONFIG_FILE=
+LIZARDFSMASTER_DEFAULTS_FILE=/etc/default/lizardfs-master
+if [ -s "$LIZARDFSMASTER_DEFAULTS_FILE" ]; then
+    . "$LIZARDFSMASTER_DEFAULTS_FILE"
+    case "x$LIZARDFSMASTER_ENABLE" in
+        xtrue) ;;
+        xfalse)
+	    log_warning_msg "lizardfs-master not enabled in \"$LIZARDFSMASTER_DEFAULTS_FILE\", exiting..."
+	    exit 0
+	    ;;
+        *)
+            log_failure_msg "value of LIZARDFSMASTER_ENABLE must be either 'true' or 'false';"
+            log_failure_msg "not starting lizardfs-master."
+            exit 1
+            ;;
+    esac
+fi
+
+set -e
+
+if [ -n "$LIZARDFSMASTER_CONFIG_FILE" ]; then
+	CFGFILE="$LIZARDFSMASTER_CONFIG_FILE"
+elif [ -f "$DEFAULT_CFG" -o ! -f "$COMPAT_CFG" ]; then
+	CFGFILE="$DEFAULT_CFG"
+else
+	CFGFILE="$COMPAT_CFG"
+fi
+
+get_config_value_from_CFGFILE()
+{
+		echo $(sed -e 's/[[:blank:]]*#.*$//' -n -e 's/^[[:blank:]]*'$1'[[:blank:]]*=[[:blank:]]*\(.*\)$/\1/p' $CFGFILE)
+}
+
+if [ -s "$CFGFILE" ]; then
+	DATA_PATH=$(get_config_value_from_CFGFILE "DATA_PATH")
+	RUN_PATH=$(get_config_value_from_CFGFILE "RUN_PATH")
+	WORKING_USER=$(get_config_value_from_CFGFILE "WORKING_USER")
+	WORKING_GROUP=$(get_config_value_from_CFGFILE "WORKING_GROUP")
+fi
+
+: ${DATA_PATH:=$DEFAULT_DATA_PATH}
+: ${RUN_PATH:=$DEFAULT_RUN_PATH}
+: ${WORKING_USER:=$DEFAULT_WORKING_USER}
+: ${WORKING_GROUP:=$DEFAULT_WORKING_GROUP}
+
+check_dirs()
+{
+	# check that the metadata dir exists
+	if [ ! -d "$DATA_PATH" ]; then
+		mkdir -p "$DATA_PATH"
+	fi
+	chmod 0755 "$DATA_PATH"
+	chown -R $WORKING_USER:$WORKING_GROUP "$DATA_PATH"
+	if [ ! -e "$DATA_PATH"/metadata.mfs ]; then
+		if [ ! -e "$DATA_PATH"/metadata.mfs.back ]; then
+			echo "LFSM NEW" > "$DATA_PATH"/metadata.mfs
+		fi
+	fi
+
+	if [ ! -d "$RUN_PATH" ]; then
+		mkdir -p "$RUN_PATH"
+	fi
+	chmod 0755 "$RUN_PATH"
+	chown -R $WORKING_USER:$WORKING_GROUP "$RUN_PATH"
+}
+
+check_status()
+{
+	# check current personality
+	if grep -q "PERSONALITY = master" "/etc/mfs/mfsmaster.cfg"
+	then
+		LFS_PERSONALITY=master
+		echo "Current personality is $LFS_PERSONALITY"
+		exit 0;
+	elif grep -q "PERSONALITY = shadow" "/etc/mfs/mfsmaster.cfg"
+	then
+		LFS_PERSONALITY=shadow
+		echo "Current personality is $LFS_PERSONALITY"
+		exit 1;
+	fi
+}
+
+become_master()
+{
+	# promote to master, making a backup of the config
+	cp /etc/mfs/mfsmaster.cfg /etc/mfs/mfsmaster.cfg.bak
+	cp /etc/mfs/mfsmaster.master.cfg /etc/mfs/mfsmaster.cfg
+
+	# reload the master service
+	service lizardfs-master reload
+
+	# force corosync to move the failover-ip to this host
+	crm resource migrate failover-ip $(hostname)
+
+	# remove the constraint that corosync just created
+	crm resource unmigrate failover-ip
+
+	exit 0;
+}
+
+become_shadow()
+{
+	# demote to shadow, making a backup of the config
+	cp /etc/mfs/mfsmaster.cfg /etc/mfs/mfsmaster.cfg.bak
+	cp /etc/mfs/mfsmaster.shadow.cfg /etc/mfs/mfsmaster.cfg
+
+	# restart the master service
+	service lizardfs-master restart
+
+	exit 0;
+}
+
+case "$1" in
+	start|master)
+		check_dirs
+		echo "Starting $DESC:"
+		become_master
+		;;
+
+	stop|slave|shadow)
+		echo "Stopping $DESC:"
+		become_shadow
+		;;
+
+	reload|force-reload)
+		echo "Option not supported. Nothing to reload."
+		;;
+
+	restart)
+		echo "Option not supported. Nothing to restart."
+		;;
+	status)
+		echo "Checking $DESC:"
+		check_status
+		;;
+	*)
+		N=/etc/init.d/$NAME
+		echo "Usage: $N {start|stop|status}" >&2
+		exit 1
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
This represents our work (with the help of the LizardFS team and others) on making a proper, official HA solution for LizardFS.

We propose using Corosync combined with this init script to manage the promotion and demotion of masters and shadow masters.

Steps to test it out:
* Install corosync and pacemaker: sudo apt-get install corosync pacemaker
* Generate a key: sudo corosync-keygen
* Copy that key to every host as /etc/corosync/authkey
* Open /etc/corosync/corosync.conf and changed mcastaddr IP to 226.94.1.1 and bind IP to 10.1.21.0 (or whatever subnet you want to run your cluster on).
* Install LizardFS in its various roles - master on at least two hosts and chunk on at least one (chunk is optional for testing).
* Change /etc/default/corosync to "yes" on all hosts
* Start corosync: sudo service corosync start
* Check the state of the cluster: sudo crm_mon -1 - it should show all nodes as part of the cluster.
* Disable STONITH: sudo crm configure property stonith-enabled=false
* Create the primitive for the failover IP (use your own IP if you want a different one): sudo crm configure primitive failover-ip ocf:_heartbeat_:IPaddr2 params ip=10.1.21.200 cidr_netmask=24 op monitor interval=0.15s
** Please note that you should change monitor interval as appropriate. We suggest values of 0.15s for a low latency cluster, 0.3s for a medium latency cluster and 1s for high latency or variable clusters. If you are using this in a production environment, 0.3s is probably the best choice.
* Change resource stickiness to prevent unnecessary movement: sudo crm configure rsc_defaults resource-stickiness=100
* If you have less than 3 hosts, disable quorum handling: sudo crm configure property no-quorum-policy=ignore
* Edit your mfsmaster.cfg so that it explicitly says "PERSONALITY = master" (not commented), then copy it to "mfsmaster.shadow.cfg" and "mfsmaster.master.cfg" in /etc/mfs - editing appropriately (ie, change the shadow.cfg to say shadow for the personality).
* Finally, add a primitive that represents the cluster: sudo crm configure primitive lizardfs-cluster lsb:lizardfs-cluster
* And make the failover-ip follow that: sudo crm configure colocation col_lizardfs-cluster_failover-ip inf: failover-ip lizardfs-cluster

This solution works solidly at this point with any number of nodes. You can also run a logger (recommended) or shadow master on your chunkservers and exclude them from being able to run the master service. Adding chunkservers into the mix is actually recommended as they will help with quorum voting to assist in preventing split-brain events.

There was a previous pull request open for this - this new one was made to clarify and update the init script and remove irrelevant changes.