### PR TITLE
Drop conf files' fallback location lookup code (legacy):

### DIFF
--- a/src/master/topology.cc
+++ b/src/master/topology.cc
@@ -430,25 +430,7 @@ void topology_reload(void) {
 	if (TopologyFileName) {
 		free(TopologyFileName);
 	}
-	if (!cfg_isdefined("TOPOLOGY_FILENAME")) {
-		TopologyFileName = strdup(ETC_PATH "/mfs/mfstopology.cfg");
-		passert(TopologyFileName);
-		if ((fd = open(TopologyFileName,O_RDONLY))<0 && errno==ENOENT) {
-			free(TopologyFileName);
-			TopologyFileName = strdup(ETC_PATH "/mfstopology.cfg");
-			if ((fd = open(TopologyFileName,O_RDONLY))>=0) {
-				lzfs_pretty_syslog(LOG_WARNING,"default sysconf path has changed - please move mfstopology.cfg from " ETC_PATH "/ to " ETC_PATH "/mfs/");
-			} else {
-				free(TopologyFileName);
-				TopologyFileName = strdup(ETC_PATH "/mfs/mfstopology.cfg");
-			}
-		}
-		if (fd>=0) {
-			close(fd);
-		}
-	} else {
-		TopologyFileName = cfg_getstr("TOPOLOGY_FILENAME", ETC_PATH "/mfs/mfstopology.cfg");
-	}
+	TopologyFileName = cfg_getstr("TOPOLOGY_FILENAME", ETC_PATH "/mfs/mfstopology.cfg");
 	topology_load();
 }
 

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -915,16 +915,6 @@ int main(int argc, char *argv[]) {
 		char *cfgfile;
 
 		cfgfile=strdup(ETC_PATH "/mfs/mfsmount.cfg");
-		if ((cfgfd = open(cfgfile,O_RDONLY))<0 && errno==ENOENT) {
-			free(cfgfile);
-			cfgfile=strdup(ETC_PATH "/mfsmount.cfg");
-			if ((cfgfd = open(cfgfile,O_RDONLY))>=0) {
-				fprintf(stderr,"default sysconf path has changed - please move mfsmount.cfg from " ETC_PATH "/ to " ETC_PATH "/mfs/\n");
-			}
-		}
-		if (cfgfd>=0) {
-			close(cfgfd);
-		}
 		mfs_opt_parse_cfg_file(cfgfile,1,&defaultargs);
 		free(cfgfile);
 	}


### PR DESCRIPTION
 LizardFS daemons try find their config files in default location in
 /etc/mfs. When config file is not found there daemons try to open config
 again from legacy location in /etc. If neither configs were found daemons
 complain that config file is expected in legacy(!) location which is
 rather confusing (and misleading) especially for new users.

 I believe this legacy fallback code is not useful and can be completely
 dropped in order to reduce maintenance burden because if admins did not
 bother to move config files to new location it may hit them anyway in the
 future when this code is finally removed. If one upgrades LizardFS daemons
 without reading "whatsnew" note about config files re-location they will
 simply get a clear error message about where config file is expected on
 service restart.

 I've made my original patch for version 2.5.4 -- it only partially applies
 to "master" so re-factored legacy fallback code still remains in the
 following files:

 * src/chunkserver/hddspacemgr.cc
 * src/main/main.cc
 * src/master/exports.cc