### PR TITLE
chunkserver: dismiss cache after closing chunk (Closes: #212):

### DIFF
--- a/EnvTests.cmake
+++ b/EnvTests.cmake
@@ -65,3 +65,5 @@ check_functions("${OPTIONAL_FUNCTIONS2}" false)
 
 check_cxx_compiler_flag(-mcrc32    CXX_HAS_MCRC32)
 check_cxx_compiler_flag(-Wno-gnu   CXX_HAS_WNOGNU)
+
+CHECK_FUNCTION_EXISTS(posix_fadvise HAVE_POSIX_FADVISE)

--- a/config.h.in
+++ b/config.h.in
@@ -101,6 +101,7 @@
 #cmakedefine LIZARDFS_HAVE_DUP2
 #cmakedefine LIZARDFS_HAVE_MLOCKALL
 #cmakedefine LIZARDFS_HAVE_GETCWD
+#cmakedefine HAVE_POSIX_FADVISE
 
 /* [CMake] Other */
 #cmakedefine WORDS_BIGENDIAN

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1541,6 +1541,9 @@ void hdd_delayed_ops() {
 				if (c->opensteps>0) {   // decrease counter
 					c->opensteps--;
 				} else if (c->fd>=0) {  // close descriptor
+#ifdef HAVE_POSIX_FADVISE
+					posix_fadvise(c->fd,0,0,POSIX_FADV_DONTNEED);
+#endif
 					if (close(c->fd)<0) {
 						hdd_error_occured(c);   // uses and preserves errno !!!
 						lzfs_silent_errlog(LOG_WARNING,"hdd_delayed_ops: file:%s - close error",c->filename);


### PR DESCRIPTION
 Dramaticaly reduce cache pressure by using POSIX_FADV_DONTNEED
 to advise OS to dismiss cached chunk after when it is closed.

Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>