### PR TITLE
chunkserver: disable USE_SPLICE by default.

### DIFF
--- a/doc/mfschunkserver.cfg.5.txt
+++ b/doc/mfschunkserver.cfg.5.txt
@@ -106,7 +106,7 @@ offset of some read operation is greater than the offset where the previos opera
 (default is 0, i.e. don't read any skipped data; the value is aligned down to 64 KiB)
 
 *USE_SPLICE*::
-whether to use splice syscall when doing disk operations on data blocks (default is 1, i.e. enabled)
+whether to use splice syscall when doing disk operations on data blocks (default is 0, i.e. disabled)
 
 *CREATE_NEW_CHUNKS_IN_MOOSEFS_FORMAT*::
 whether to create new chunks in the MooseFS format (signature + <checksum>* + <data block>*) or in

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -92,7 +92,7 @@ void mainNetworkThreadReload(void) {
 			"NR_OF_HDD_WORKERS_PER_NETWORK_WORKER", gNrOfHddWorkersPerNetworkWorker);
 	cfg_warning_on_value_change(
 			"BGJOBSCNT_PER_NETWORK_WORKER", gBgjobsCountPerNetworkWorker);
-	NetworkWorkerThread::useSplice = cfg_getint32("USE_SPLICE", 1);
+	NetworkWorkerThread::useSplice = cfg_getint32("USE_SPLICE", 0);
 
 	try {
 		replicationBandwidthLimitReload();
@@ -214,7 +214,7 @@ int mainNetworkThreadInit(void) {
 			"NR_OF_HDD_WORKERS_PER_NETWORK_WORKER", 2, 1);
 	gBgjobsCountPerNetworkWorker = cfg_get_minvalue<uint32_t>(
 			"BGJOBSCNT_PER_NETWORK_WORKER", 1000, 10);
-	NetworkWorkerThread::useSplice = cfg_getint32("USE_SPLICE", 1);
+	NetworkWorkerThread::useSplice = cfg_getint32("USE_SPLICE", 0);
 
 	gHDDReadAhead.setReadAhead_kB(
 			cfg_get_maxvalue<uint32_t>("READ_AHEAD_KB", 0, MFSCHUNKSIZE / 1024));

--- a/src/data/mfschunkserver.cfg.in
+++ b/src/data/mfschunkserver.cfg.in
@@ -56,7 +56,6 @@
 
 # READ_AHEAD_KB = 0
 # MAX_READ_BEHIND_KB = 0
-# USE_SPLICE = 1
 
 ## Name of volume configuration file.
 ## (Default: @ETC_PATH@/mfshdd.cfg)
@@ -104,8 +103,10 @@
 # MAX_READ_BEHIND_KB = 0
 
 ## Whether to use splice syscall when doing disk operations on data blocks.
-## (Default: 1), i.e. enabled.
-# USE_SPLICE = 1
+## Warning: Current implementation does not prevent data from being
+## modified during reading which causes occasional read errors.
+## (Default: 0), i.e. disabled.
+# USE_SPLICE = 0
 
 ## Whether to create new chunks in the MooseFS format
 ##    (signature + <checksum>* + <data block>*)


### PR DESCRIPTION
> "Current implementation may cause spurious situations when data is modified
 during reading. Default configurations will be updated to set splice as not default (or, more likely, totally removed)."
    -- https://github.com/lizardfs/lizardfs/issues/378#issuecomment-184216358
