### PR TITLE
Resolve 'mfsmaster' to connect CGI server to master

### DIFF
--- a/src/cgi/mfs.cgi.in
+++ b/src/cgi/mfs.cgi.in
@@ -60,7 +60,7 @@ try:
 	if fields.has_key("masterhost"):
 		masterhost = fields.getvalue("masterhost")
 	else:
-		masterhost = '127.0.0.1'
+		masterhost = socket.gethostbyname('mfsmaster')
 except Exception:
 	masterhost = '127.0.0.1'
 try:


### PR DESCRIPTION
Currently, the CGI server uses the hard-coded loopback IP for the master host
without an option to change this address.

Other parts of LizardFS (e.g. shadow master) try to resolve 'mfsmaster' when
connecting to the master server. I reproduced the same behavior for the CGI
server. If 'mfsmaster' cannot be resolved, it will fall back to the loopback
IP, which ensures backwards-compatibility.