### PR TITLE
increase inode reuse delay from 1 day to 30 days

### DIFF
--- a/src/protocol/MFSCommunication.h
+++ b/src/protocol/MFSCommunication.h
@@ -83,7 +83,7 @@
 #define MFS_NAME_MAX 255
 #define MFS_MAX_FILE_SIZE (((uint64_t)(MFSCHUNKSIZE))<<31)
 
-#define MFS_INODE_REUSE_DELAY 86400
+#define MFS_INODE_REUSE_DELAY 259200
 
 /// field values: status
 #define LIZARDFS_STATUS_OK                      0    // OK


### PR DESCRIPTION
Increase inode reuse delay from 1 day to 30 days. This makes it much harder to run into inode reuse issues, as I did in my cluster.