### PR TITLE
Use CFGFILE in debian init script

### DIFF
--- a/debian/lizardfs-chunkserver.init
+++ b/debian/lizardfs-chunkserver.init
@@ -82,24 +82,24 @@ case "$1" in
 	start)
 		check_dirs
 		echo "Starting $DESC:"
-		$DAEMON ${LIZARDFSCHUNKSERVER_CONFIG_FILE:+-c $LIZARDFSCHUNKSERVER_CONFIG_FILE} $DAEMON_OPTS start
+		$DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
 		;;
 
 	stop)
 		echo "Stopping $DESC:"
-		$DAEMON ${LIZARDFSCHUNKSERVER_CONFIG_FILE:+-c $LIZARDFSCHUNKSERVER_CONFIG_FILE} stop
+		$DAEMON ${CFGFILE:+-c $CFGFILE} stop
 		;;
 
 	reload|force-reload)
 		check_dirs
 		echo "Reloading $DESC:"
-		$DAEMON ${LIZARDFSCHUNKSERVER_CONFIG_FILE:+-c $LIZARDFSCHUNKSERVER_CONFIG_FILE} reload
+		$DAEMON ${CFGFILE:+-c $CFGFILE} reload
 		;;
 
 	restart)
 		check_dirs
 		echo "Restarting $DESC:"
-		$DAEMON ${LIZARDFSCHUNKSERVER_CONFIG_FILE:+-c $LIZARDFSCHUNKSERVER_CONFIG_FILE} $DAEMON_OPTS restart
+		$DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS restart
 		;;
 
 	*)

--- a/debian/lizardfs-master.init
+++ b/debian/lizardfs-master.init
@@ -79,23 +79,23 @@ case "$1" in
 	start)
 		check_dirs
 		echo "Starting $DESC:"
-		$DAEMON ${LIZARDFSMASTER_CONFIG_FILE:+-c $LIZARDFSMASTER_CONFIG_FILE} $DAEMON_OPTS start
+		$DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
 		;;
 
 	stop)
 		echo "Stopping $DESC:"
-		$DAEMON ${LIZARDFSMASTER_CONFIG_FILE:+-c $LIZARDFSMASTER_CONFIG_FILE} stop
+		$DAEMON ${CFGFILE:+-c $CFGFILE} stop
 		;;
 
 	reload|force-reload)
 		echo "Reloading $DESC:"
-		$DAEMON ${LIZARDFSMASTER_CONFIG_FILE:+-c $LIZARDFSMASTER_CONFIG_FILE} reload
+		$DAEMON ${CFGFILE:+-c $CFGFILE} reload
 		;;
 
 	restart)
 		check_dirs
 		echo "Restarting $DESC:"
-		$DAEMON ${LIZARDFSMASTER_CONFIG_FILE:+-c $LIZARDFSMASTER_CONFIG_FILE} restart
+		$DAEMON ${CFGFILE:+-c $CFGFILE} restart
 		;;
 
 	*)

--- a/debian/lizardfs-metalogger.init
+++ b/debian/lizardfs-metalogger.init
@@ -79,25 +79,25 @@ case "$1" in
 	start)
 		check_dirs
 		echo "Starting $DESC:"
-		$DAEMON ${LIZARDFSMETALOGGER_CONFIG_FILE:+-c $LIZARDFSMETALOGGER_CONFIG_FILE} $DAEMON_OPTS start
+		$DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
 		;;
 
 	stop)
 		echo "Stopping $DESC:"
-		$DAEMON ${LIZARDFSMETALOGGER_CONFIG_FILE:+-c $LIZARDFSMETALOGGER_CONFIG_FILE} stop
+		$DAEMON ${CFGFILE:+-c $CFGFILE} stop
 		echo "$NAME."
 		;;
 
 	reload|force-reload)
 		check_dirs
 		echo "Reloading $DESC:"
-		$DAEMON ${LIZARDFSMETALOGGER_CONFIG_FILE:+-c $LIZARDFSMETALOGGER_CONFIG_FILE} reload
+		$DAEMON ${CFGFILE:+-c $CFGFILE} reload
 		;;
 
 	restart)
 		check_dirs
 		echo "Restarting $DESC:"
-		$DAEMON ${LIZARDFSMETALOGGER_CONFIG_FILE:+-c $LIZARDFSMETALOGGER_CONFIG_FILE} $DAEMON_OPTS restart
+		$DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS restart
 		;;
 
 	*)


### PR DESCRIPTION
The debian init script defines LIZARDFSMASTER_CONFIG_FILE and uses that to set CFGFILE

The latter should be used in stopping and starting the master daemon.
