### PR TITLE
[main] Remove supplementary groups when dropping privileges

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -374,6 +374,7 @@ void changeugid(RunMode runmode) {
 		free(wuser);
 		free(wgroup);
 
+		setgroups(0, NULL);
 		if (setgid(wrk_gid)<0) {
 			lzfs_pretty_errlog(LOG_ERR,"can't set gid to %d",(int)wrk_gid);
 			exit(LIZARDFS_EXIT_STATUS_ERROR);


### PR DESCRIPTION
When dropping privileges, remove supplementary groups which may give
unnecessary access.

This will fail if we're not root, at which point the next statement will
also fail, so don't bother checking return value.

Signed-off-by: Jonathan Dieter <jdieter@lesbg.com>