### PR TITLE
[common] Fix overflow error with GCC 7

### DIFF
--- a/src/common/galois_coeff.h
+++ b/src/common/galois_coeff.h
@@ -38,7 +38,7 @@ constexpr uint8_t gf_mul2(uint8_t x) {
  * \return log(x)
  */
 constexpr uint8_t gf_log(uint8_t x, uint8_t pow2n = 2, uint8_t n = 1) {
-	return x == pow2n ? n : gf_log(x, gf_mul2(pow2n), n + 1);
+	return x == pow2n ? n : gf_log(x, gf_mul2(pow2n), n + 1U);
 }
 
 /*! \brief Compute base 2 exponent in GF(2^8).
@@ -48,7 +48,7 @@ constexpr uint8_t gf_log(uint8_t x, uint8_t pow2n = 2, uint8_t n = 1) {
  * \return exp(x)
  */
 constexpr uint8_t gf_exp(uint8_t x, uint8_t pow2n = 2, uint8_t n = 1) {
-	return x == n ? pow2n : gf_exp(x, gf_mul2(pow2n), n + 1);
+	return x == n ? pow2n : gf_exp(x, gf_mul2(pow2n), n + 1U);
 }
 
 /*! \brief Returns lookup table for base 2 logarithm in GF(2^8). */


### PR DESCRIPTION
Make sure n is always added to unsigned 1 to avoid overflow errors.  This fixes a bug I was running into when trying to compile on Fedora rawhide:

```
/builddir/build/BUILD/lizardfs-3.10.6/src/common/galois_coeff.h:69:53: error: overflow in constant expression [-fpermissive]
  detail::get_gf_log_table(make_index_sequence<255>());
```

The [failing build log is here](https://kojipkgs.fedoraproject.org//work/tasks/3362/19103362/build.log)

Signed-off-by: Jonathan Dieter <jdieter@lesbg.com>