### PR TITLE
mount: Fix 32-bit build for mfsmount3

### DIFF
--- a/src/mount/lizard_client.h
+++ b/src/mount/lizard_client.h
@@ -249,7 +249,11 @@ struct EntryParam {
 	}
 
 	Inode ino;
+#if FUSE_USE_VERSION >= 30
+	uint64_t generation;
+#else
 	unsigned long generation;
+#endif
 	struct stat attr;
 	double attr_timeout;
 	double entry_timeout;


### PR DESCRIPTION
The FUSE3 client doesn't build on 32-bit because generation is uint64_t in FUSE3 rather than unsigned long
This patch fixes it so if FUSE_USE_VERSION >= 30, then we set generation to uint64_t.