### PR TITLE
Install proper manpage for mfsmount3 instead of symlink

### DIFF
--- a/debian/lizardfs-client3.install
+++ b/debian/lizardfs-client3.install
@@ -1,1 +1,2 @@
 usr/bin/mfsmount3
+usr/share/man/man1/mfsmount3.1

--- a/debian/lizardfs-client3.postinst
+++ b/debian/lizardfs-client3.postinst
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-ln -s usr/share/man/man1/mfsmount.1 usr/share/man/man1/mfsmount3.1

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -78,4 +78,18 @@ foreach(MANPAGE ${MANPAGES})
   # Install the generated file
   install(FILES ${GENERATED_MANPAGE_PATH} DESTINATION ${MAN_SUBDIR}/man${SECTION_NUMBER})
 endforeach()
+
+# mfsmount3.1 is special, since it should be available even if we do not install the
+# fuse2 package with mfsmount.1. Make a copy in the binary directory and replace
+# the string "mfsmount" with "mfsmount3".
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/mfsmount.1.txt MFSMOUNT1)
+string(REPLACE "mfsmount" "mfsmount3" MFSMOUNT3 ${MFSMOUNT1})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/mfsmount3.1 ${MFSMOUNT3})
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mfsmount3.1
+    COMMAND a2x ${ASCIIDOC_VERBOSE} -L -f manpage ${CMAKE_CURRENT_BINARY_DIR}/mfsmount3.1.txt
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mfsmount.1.txt)
+set(GENERATED_MANPAGES ${GENERATED_MANPAGES} ${CMAKE_CURRENT_BINARY_DIR}/mfsmount3.1)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mfsmount3.1 DESTINATION ${MAN_SUBDIR}/man1)
+
 add_custom_target(manpages ALL SOURCES ${GENERATED_MANPAGES})

--- a/rpm/lizardfs.spec
+++ b/rpm/lizardfs.spec
@@ -476,6 +476,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files client3
 %attr(755,root,root) %{_bindir}/mfsmount3
+%{_mandir}/man1/mfsmount3.1*
 
 %files lib-client
 %{_libdir}/liblizardfsmount_shared.so


### PR DESCRIPTION
Since it is possible to install only the client3 version,
we do not want the manpage to only be a symlink to the
version using fuse2, but instead we replace strings and
generate a separate stand-alone manpage.

This also fixes the issue with symlinks in post-install scripts
failing when installed manpages are compressed, and the
installed link not being properly tracked as belonging to
the package.