### PR TITLE
chunkserver: Add advertise address capability

### DIFF
--- a/doc/mfschunkserver.cfg.5.txt
+++ b/doc/mfschunkserver.cfg.5.txt
@@ -67,6 +67,10 @@ port to listen on for client (mount) connections (default is 9422)
 *CSSERV_TIMEOUT*::
 timeout (in seconds) for client (mount) connections (default is 5)
 
+*CSSERV_ADVERTISE_ADDR*::
+IP address to advertise to clients. This should be set if running behind a NAT
+or in a Docker container.
+
 *HDD_CONF_FILENAME*::
 alternative name of *mfshdd.cfg* file
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -175,6 +175,12 @@ void masterconn_sendregister(masterconn *eptr) {
 	uint32_t chunkcount,tdchunkcount;
 
 	myip = mainNetworkThreadGetListenIp();
+	// Advertise another address
+	if (cfg_isdefined("CSSERV_ADVERTISE_ADDR") and tcpresolve(cfg_getstr("CSSERV_ADVERTISE_ADDR", ""), NULL, &myip, NULL, 1)<0) {
+		lzfs_pretty_syslog(LOG_WARNING, "Invalid advertise IP or hostname, using listen IP instead");
+		myip = mainNetworkThreadGetListenIp();
+	}
+
 	myport = mainNetworkThreadGetListenPort();
 	masterconn_create_attached_packet(eptr, cstoma::registerHost::build(myip, myport, Timeout_ms, LIZARDFS_VERSHEX));
 


### PR DESCRIPTION
Allows setting `CSSERV_ADVERTISE_ADDR` so that the IP address advertised from a chunk server to a master can be different than the IP address the chunk server is listening on. This is mainly needed behind a NAT or when operating a chunk server within a Docker container. This resolves #721.