### PR TITLE
tools: fix mfstools.sh (infinite recursion)

### DIFF
--- a/src/tools/mfstools.sh
+++ b/src/tools/mfstools.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-tool=$(basename $0)
-
-${tool/lizardfs/lizardfs } "$@"
+tool="$(basename $0)"
+case "$tool" in
+  (lizardfs*) tool="${tool#lizardfs}" ;;
+  (mfs*) tool="${tool#mfs}" ;;
+esac
+exec lizardfs "${tool}" "$@"


### PR DESCRIPTION
Fixes #886.

An example error message was:

```
LC_ALL=C bash -x /usr/bin/mfssetgoal --help
++ basename /usr/bin/mfssetgoal
+ tool=mfssetgoal
+ mfssetgoal --help
bash: warning: shell level (1000) too high, resetting to 1
```