### PR TITLE
Missing dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,8 @@ Build-Depends: asciidoc (>= 8.6.6),
                libboost-system-dev,
                libboost-program-options-dev,
                python3,
+               black,
+               python3-mypy,
 Standards-Version: 3.9.3
 Homepage: http://lizardfs.org/
 


### PR DESCRIPTION
If you require black and mypy, you should tell the Debian control file.