### PR TITLE
Fix early readahead cache expiry

### DIFF
--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -371,6 +371,7 @@ int read_data(void *rr, uint64_t offset, uint32_t size, ReadCache::Result &ret) 
 		result.inputBuffer().clear();
 		return err;
 	}
+	result.entries.back()->reset_timer();
 
 	ret = std::move(result);
 	return LIZARDFS_STATUS_OK;

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -78,6 +78,10 @@ public:
 			assert(refcount > 0);
 			refcount--;
 		}
+
+		void reset_timer() {
+			timer.reset();
+		}
 	};
 
 	typedef boost::intrusive::set<Entry,


### PR DESCRIPTION
Currently, cache entry timers are started at entry creation time. This leads to situations where cache entries would reach their expiration time while they were still being received. As a result, the client ends up requesting and receiving highly overlapping data blocks. From Wireshark traces of a simple sequential read benchmark with a single chunkserver, I observed a 3x data size difference between chunkserver requests and application requests.