### PR TITLE
mount: Fix typos in the `funcs` comments

### DIFF
--- a/src/mount/special_open.cc
+++ b/src/mount/special_open.cc
@@ -116,6 +116,7 @@ static const std::array<std::function<void
 	 &InodeOplog::open,             //0x1U
 	 &InodeOphistory::open,         //0x2U
 	 &InodeTweaks::open,            //0x3U
+	 nullptr,                       //0x4U
 	 nullptr,                       //0x5U
 	 nullptr,                       //0x6U
 	 nullptr,                       //0x7U
@@ -125,7 +126,6 @@ static const std::array<std::function<void
 	 nullptr,                       //0xBU
 	 nullptr,                       //0xCU
 	 nullptr,                       //0xDU
-	 nullptr,                       //0xEU
 	 nullptr,                       //0xEU
 	 &InodeMasterInfo::open         //0xFU
 }};

--- a/src/mount/special_read.cc
+++ b/src/mount/special_read.cc
@@ -186,6 +186,7 @@ static const std::array<std::function<std::vector<uint8_t>
 	 &InodeOplog::read,             //0x1U
 	 &InodeOphistory::read,         //0x2U
 	 &InodeTweaks::read,            //0x3U
+	 nullptr,                       //0x4U
 	 nullptr,                       //0x5U
 	 nullptr,                       //0x6U
 	 nullptr,                       //0x7U
@@ -195,7 +196,6 @@ static const std::array<std::function<std::vector<uint8_t>
 	 nullptr,                       //0xBU
 	 nullptr,                       //0xCU
 	 nullptr,                       //0xDU
-	 nullptr,                       //0xEU
 	 nullptr,                       //0xEU
 	 &InodeMasterInfo::read         //0xFU
 }};

--- a/src/mount/special_release.cc
+++ b/src/mount/special_release.cc
@@ -98,6 +98,7 @@ static const std::array<ReleaseFunc, 16> funcs = {{
 	 &InodeOplog::release,          //0x1U
 	 &InodeOphistory::release,      //0x2U
 	 &InodeTweaks::release,         //0x3U
+	 nullptr,                       //0x4U
 	 nullptr,                       //0x5U
 	 nullptr,                       //0x6U
 	 nullptr,                       //0x7U
@@ -107,7 +108,6 @@ static const std::array<ReleaseFunc, 16> funcs = {{
 	 nullptr,                       //0xBU
 	 nullptr,                       //0xCU
 	 nullptr,                       //0xDU
-	 nullptr,                       //0xEU
 	 nullptr,                       //0xEU
 	 &InodeMasterInfo::release      //0xFU
 }};

--- a/src/mount/special_write.cc
+++ b/src/mount/special_write.cc
@@ -101,6 +101,7 @@ static const std::array<std::function<BytesWritten
 	 &InodeOplog::write,            //0x1U
 	 &InodeOphistory::write,        //0x2U
 	 &InodeTweaks::write,           //0x3U
+	 nullptr,                       //0x4U
 	 nullptr,                       //0x5U
 	 nullptr,                       //0x6U
 	 nullptr,                       //0x7U
@@ -110,7 +111,6 @@ static const std::array<std::function<BytesWritten
 	 nullptr,                       //0xBU
 	 nullptr,                       //0xCU
 	 nullptr,                       //0xDU
-	 nullptr,                       //0xEU
 	 nullptr,                       //0xEU
 	 &InodeMasterInfo::write        //0xFU
 }};


### PR DESCRIPTION
The `funcs` array definition has placeholders with comments for hinting at the expected matching inode for each position
As some comments were not following the proper sequence, there was a chance somebody could be led to set a function in a mistaken slot