### PR TITLE
handling getxattr outside of try-catch

### DIFF
--- a/src/mount/fuse/mfs_fuse.cc
+++ b/src/mount/fuse/mfs_fuse.cc
@@ -591,6 +591,13 @@ void mfs_getxattr (fuse_req_t req, fuse_ino_t ino, const char *name, size_t size
 void mfs_getxattr (fuse_req_t req, fuse_ino_t ino, const char *name, size_t size) {
 	uint32_t position=0;
 #endif /* __APPLE__ */
+	//   handling `security.capability` is not suppported for now, always returning an error.
+	//   so, moving the condition outside of try-catch significantly increases perfomance for iops tests.
+    	if (strcmp(name,"security.capability")==0) {
+        	fuse_reply_err(req, 95);
+        	return;
+    	}
+
 	try {
 		auto ctx = get_context(req);
 		auto a = LizardClient::getxattr(ctx, ino, name, size, position);


### PR DESCRIPTION
```
	//   handling `security.capability` is not suppported for now, always returning an error.
	//   so, moving the condition outside of try-catch significantly increases perfomance for iops tests.
```