### PR TITLE
build: Fix aarch64 compiling error: comparison is always true due to limited range of data type

### DIFF
--- a/src/tools/recursive_remove.cc
+++ b/src/tools/recursive_remove.cc
@@ -121,7 +121,13 @@ static int recursive_remove(const char *file_name, int long_wait) {
 }
 
 int recursive_remove_run(int argc, char **argv) {
-	char ch;
+	/*
+	 * char ch;
+	 * ch type should be int instead of type char, for aarch64 compiling error:
+	 * while ((ch = getopt(argc, argv, "l")) != -1) comparison is always true due to limited range of data type
+	*/ 
+	int ch; 
+	
 	int status;
 	int long_wait = 0;
 


### PR DESCRIPTION
fix issue when compiling for aarch64 arch.
https://github.com/lizardfs/lizardfs/issues/932